### PR TITLE
v0.2.0: built-in functions, friendly errors, import from curl, working release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         uses: mlugg/setup-zig@v2
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test
       # Tag pushes (v*) publish a real release; everything else is a
       # cross-compile smoke test that publishes nothing.
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,15 @@ jobs:
           args: release --clean ${{ github.ref_type != 'tag' && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      # Tag runs publish these to the GitHub Release; snapshot runs attach
+      # them to the workflow so PR builds are downloadable too.
+      - name: Upload snapshot artifacts
+        if: github.ref_type != 'tag'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lazyreq-snapshot-${{ github.sha }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*_checksums.txt
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: goreleaser
+name: release
 
 on:
-  pull_request:
   push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
 
 permissions:
   contents: write
@@ -15,19 +17,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v5
-      - name: Setup musl
-        run: |
-          sudo apt-get install pkg-config libssl-dev
-          sudo apt-get install -y musl
+      - name: Set up Rust
+        run: rustup toolchain install stable --profile minimal
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      # Tag pushes (v*) publish a real release; everything else is a
+      # cross-compile smoke test that publishes nothing.
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --snapshot
+          args: release --clean ${{ github.ref_type != 'tag' && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,7 @@ version: 2
 before:
   hooks:
     - rustup default stable
+    - rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin x86_64-pc-windows-gnu
     - cargo install --locked cargo-zigbuild
     - cargo fetch --locked
 
@@ -22,7 +23,7 @@ builds:
     skip: false
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -32,7 +33,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 universal_binaries:
   - replace: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -130,6 +145,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,41 +201,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -217,12 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,12 +249,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -291,6 +317,21 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -360,16 +401,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -519,17 +561,22 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyreq"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-recursion",
+ "base64 0.22.1",
  "colored",
+ "hex",
+ "hmac",
  "home",
  "mime_guess",
- "openssl",
+ "rand",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
+ "sha2",
  "tokio",
  "uuid",
 ]
@@ -539,12 +586,6 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -611,23 +652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,60 +665,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.108"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -738,18 +708,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -775,6 +748,36 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -820,7 +823,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -829,16 +832,16 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -846,13 +849,28 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -862,16 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "1.0.7"
+name = "rustls"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
 ]
 
 [[package]]
@@ -880,7 +897,17 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -896,41 +923,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "sct"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "bitflags 2.9.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -978,6 +983,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1049,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1073,19 +1106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,12 +1145,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -1179,6 +1199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1215,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1213,14 +1245,14 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1326,6 +1358,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "windows-sys"
@@ -1522,6 +1560,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,26 +61,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -119,6 +113,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "colored"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,26 +140,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -186,27 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,12 +212,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -271,8 +248,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -283,8 +262,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -292,31 +285,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hex"
@@ -344,23 +312,34 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -371,47 +350,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
+ "hyper-util",
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -522,16 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,13 +548,13 @@ name = "lazyreq"
 version = "0.2.0"
 dependencies = [
  "async-recursion",
- "base64 0.22.1",
+ "base64",
  "colored",
  "hex",
  "hmac",
  "home",
  "mime_guess",
- "rand",
+ "rand 0.8.7",
  "regex",
  "reqwest",
  "serde",
@@ -608,6 +592,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -686,7 +676,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -735,6 +725,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +809,18 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -767,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -780,12 +843,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -819,44 +897,42 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-rustls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
 ]
 
 [[package]]
@@ -880,33 +956,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustls"
-version = "0.21.12"
+name = "rustc-hash"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls-pki-types"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "base64 0.21.7",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -927,16 +1013,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "serde"
@@ -989,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1000,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1069,9 +1145,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1085,24 +1164,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
+ "thiserror-impl",
 ]
 
 [[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "core-foundation-sys",
- "libc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1114,6 +1192,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1146,26 +1239,52 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.15"
+name = "tower"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
- "bytes",
  "futures-core",
- "futures-sink",
+ "futures-util",
  "pin-project-lite",
+ "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
 ]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -1360,18 +1479,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "webpki-roots"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
- "windows-targets 0.48.5",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1380,7 +1503,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1389,22 +1512,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1413,21 +1521,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1437,21 +1539,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1467,21 +1557,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1491,21 +1569,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1514,22 +1580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1602,6 +1658,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +130,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -127,6 +148,30 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -158,12 +203,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -187,6 +242,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -516,6 +581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +623,9 @@ version = "0.2.0"
 dependencies = [
  "async-recursion",
  "base64",
+ "chacha20poly1305",
  "colored",
+ "flate2",
  "hex",
  "hmac",
  "home",
@@ -628,6 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -655,6 +732,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -696,6 +779,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -818,7 +912,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1096,6 +1190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1434,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +356,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hex"
@@ -578,6 +590,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1134,6 +1156,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/2yuri/lazyreq"
 [dependencies]
 regex = "1.10.6"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lazyreq"
 version = "0.2.0"
 edition = "2021"
+license = "MIT"
+description = "A lazy, file-based HTTP client for your terminal"
+repository = "https://github.com/2yuri/lazyreq"
 
 [dependencies]
 regex = "1.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "lazyreq"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
 regex = "1.10.6"
-reqwest = { version = "0.11", features = ["blocking", "json", "multipart"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3", features = ["v4"] }
@@ -14,4 +14,9 @@ async-recursion = "1.1.1"
 colored = "2.0"
 home = "0.5"
 mime_guess = "2.0"
-openssl = { version = "0.10", features = ["vendored"] }
+rand = "0.8"
+hmac = "0.12"
+sha1 = "0.10"
+sha2 = "0.10"
+base64 = "0.22"
+hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 async-recursion = "1.1.1"
+chacha20poly1305 = "0.10"
 colored = "2.0"
+flate2 = "1.0"
 home = "0.5"
 mime_guess = "2.0"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/2yuri/lazyreq"
 
 [dependencies]
 regex = "1.10.6"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json", "multipart"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3", features = ["v4"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 2yuri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
 lazyreq <file.lreq> --list                # list every request in the file
 lazyreq <file.lreq> --history             # past runs of every request in the file
 lazyreq <file.lreq> <request-id> --history  # past runs of one request
+lazyreq <file.lreq> --retry <run-id>      # replay a recorded run (exact body, fresh auth)
 lazyreq import '<curl command>'           # convert a curl command to a request block
 lazyreq --version                         # print the CLI version
 ```
@@ -112,13 +113,15 @@ Every executed request — including hook-triggered logins — is recorded into 
 
 ```sh
 $ lazyreq api.lreq --history
-2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
-2026-07-13 21:04:12  me     GET     200     1ms  body:83b  headers:1
+0853d0e6  2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
+4645a373  2026-07-13 21:04:12  me     GET     200     1ms  body:83b  headers:1
 
 $ lazyreq api.lreq login --history --last 1
-2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
+0853d0e6  2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
     {token: str(212), user: {email: str(14), id: int}}
 ```
+
+The first column is the **run id** — a unique id per execution, distinct from the request's `ID:` name.
 
 The single-request view summarizes each response as a **JSON shape** — keys and types instead of values — so you (or an AI agent) can see what an endpoint returns without dumping payloads. Escalate detail only when needed:
 
@@ -128,7 +131,16 @@ lazyreq api.lreq login --history -v --show-headers  # + the actual request heade
 lazyreq api.lreq --history --failed               # only non-2xx and transport errors
 lazyreq api.lreq --history --status 401           # only a specific status
 lazyreq api.lreq --history --success --last 5     # 2xx only, most recent 5
+lazyreq api.lreq --history --req 0853d0e6 -v      # one specific run, by run id
 ```
+
+### Retrying a run
+
+```sh
+lazyreq api.lreq --retry 0853d0e6
+```
+
+`--retry` replays a recorded run: the **recorded URL and body are sent verbatim** — including generated `$uuid()` / `$fuzz_*()` values, which a normal re-run would regenerate — while **headers are re-resolved** from the current request definition, so auth hooks produce fresh tokens and `$hmac($body, ...)` signatures are recomputed over the replayed body. That makes it ideal for reproducing a failing request exactly. The retry is recorded as a new run with its own run id.
 
 Failed sends (DNS, refused connections, timeouts) are recorded too, with the error message in place of a body. The newest 20 runs per request id are kept; `--curl` and `--list` execute nothing and record nothing.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ HOOKS
 | Line | Meaning |
 |---|---|
 | `ID: name` | starts a request block |
+| `DESCRIPTION: text` | optional human-readable description, shown by `--list` and in the editor sidebar |
 | `METHOD url` | `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD` or `OPTIONS` — must come first |
 | `H: Name = value` | a header |
 | `M: name = value` | a multipart form field (sets up `multipart/form-data`) |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ lazyreq api.lreq login
 - **Your API collection is a text file.** It lives in your repo, diffs like code, and works in CI. No GUI, no cloud workspace, no JSON exports.
 - **Auth that gets out of the way.** Hooks run your login request automatically, extract the token from its JSON, and cache it — every other request just says `$login.token`.
 - **Sign, fuzz, generate.** Built-in `$hmac()`, `$uuid()`, `$fuzz_str()` and `$fuzz_int()` cover webhook signatures and quick fuzzing without leaving the file.
+- **Every run is remembered.** An encrypted local history records what was sent and what came back — query it with `--history` instead of re-running requests.
+- **Built for AI agents too.** Compact, structured output and persistent memory make it dramatically more token-efficient than curl for LLM workflows ([see below](#lazyreq-for-llm-agents)).
 - **Escape hatch included.** Any request exports as a ready-to-paste `curl` command.
 
 ## Quick start
@@ -77,6 +79,8 @@ Prefer clicking? There's a [VS Code / Cursor extension](https://github.com/2yuri
 lazyreq <file.lreq> <request-id>          # run a request
 lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
 lazyreq <file.lreq> --list                # list every request in the file
+lazyreq <file.lreq> --history             # past runs of every request in the file
+lazyreq <file.lreq> <request-id> --history  # past runs of one request
 lazyreq import '<curl command>'           # convert a curl command to a request block
 lazyreq --version                         # print the CLI version
 ```
@@ -102,6 +106,52 @@ H: Authorization = Bearer tok
 
 Append it to a collection with `lazyreq import '...' >> api.lreq`. Supports `-X`, `-H`, `-d`/`--data*`, `-F` (with `@file` → `file://`), `-u` (→ basic auth header), `-b`, `-A`, `-e` and `--url`; literal `$` in values is escaped automatically.
 
+## Run history
+
+Every executed request — including hook-triggered logins — is recorded into an encrypted history under `~/.lazyreq/history/`, keyed by the file's absolute path. Query it instead of re-running things:
+
+```sh
+$ lazyreq api.lreq --history
+2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
+2026-07-13 21:04:12  me     GET     200     1ms  body:83b  headers:1
+
+$ lazyreq api.lreq login --history --last 1
+2026-07-13 21:04:12  login  POST    200     3ms  body:76b  headers:1
+    {token: str(212), user: {email: str(14), id: int}}
+```
+
+The single-request view summarizes each response as a **JSON shape** — keys and types instead of values — so you (or an AI agent) can see what an endpoint returns without dumping payloads. Escalate detail only when needed:
+
+```sh
+lazyreq api.lreq login --history -v               # resolved URL, request body, full response
+lazyreq api.lreq login --history -v --show-headers  # + the actual request headers
+lazyreq api.lreq --history --failed               # only non-2xx and transport errors
+lazyreq api.lreq --history --status 401           # only a specific status
+lazyreq api.lreq --history --success --last 5     # 2xx only, most recent 5
+```
+
+Failed sends (DNS, refused connections, timeouts) are recorded too, with the error message in place of a body. The newest 20 runs per request id are kept; `--curl` and `--list` execute nothing and record nothing.
+
+**Encryption.** History and the hook cache are gzipped and encrypted at rest (XChaCha20-Poly1305) with a machine key auto-generated at `~/.lazyreq/key` (mode 0600). Set `LAZYREQ_KEY` to use your own key instead — useful in CI or to share history between machines. Responses often contain tokens and personal data; encrypting them means a synced home directory, a backup, or a stray `cat` can't leak what your APIs returned.
+
+## lazyreq for LLM agents
+
+`.lreq` files were designed to be the API memory an AI coding agent doesn't have. If you let an agent (Claude Code, Cursor, ...) test APIs with raw `curl`, you pay three taxes:
+
+1. **Repetition tax.** Every curl invocation re-states the base URL, headers, auth token and body — hundreds of tokens each time, assembled from scratch. With lazyreq the collection is written once; afterwards a request is `lazyreq api.lreq me` — a handful of tokens, no matter how complex the request.
+2. **Auth tax.** With curl, the agent must run the login call, read the token out of the response *into its context window* (where it's now permanently transcribed), and paste it into every following command. lazyreq hooks resolve `$login.token` internally — the token flows from response to header without ever entering the conversation, and the TTL cache means login isn't hammered.
+3. **Context-loss tax.** An agent's memory dies with its session (or earlier, when the conversation is compacted). Yesterday's "what did that endpoint return?" is gone, so agents re-run requests — including unsafe POSTs — just to re-learn what they already knew. lazyreq's history survives on disk: a fresh session runs `--history` and gets back status, latency and the response's JSON shape in ~30 tokens, instead of a 3,000-token payload dump or a live re-execution.
+
+The compact-by-default output is deliberate: list views are one line per run, response bodies are summarized as shapes (`{token: str(212), user: {id: int}}`), and full payloads or headers appear only behind explicit flags (`-v`, `--show-headers`). The agent escalates detail only when it needs it.
+
+**Skill.** This repo ships a ready-made skill for Claude Code and compatible agents at [`skills/lazyreq/`](skills/lazyreq/) — it teaches the agent the `.lreq` format, the CLI, and the history-first workflow. Install it by copying (or symlinking) the folder:
+
+```sh
+cp -r skills/lazyreq ~/.claude/skills/          # user-wide
+# or per project:
+cp -r skills/lazyreq your-project/.claude/skills/
+```
+
 ## The .lreq format
 
 A file has three kinds of sections: `VARS`, `HOOKS`, and one block per request starting with `ID:`.
@@ -122,7 +172,7 @@ HOOKS
   login = $req.login 30
 ```
 
-`$req.<id>` names the request to run; the optional number is a cache TTL in seconds. Cached responses live in `~/.lazyreq/cache/` keyed by (file, request id), so a login token is fetched once and reused until it expires. Without a TTL the hook runs on every use.
+`$req.<id>` names the request to run; the optional number is a cache TTL in seconds. Cached responses live encrypted in `~/.lazyreq/cache/`, keyed by the file's absolute path + request id, so a login token is fetched once and reused until it expires. Without a TTL the hook runs on every use.
 
 ### Requests
 
@@ -210,7 +260,6 @@ The exit code is 1 on any error, so `.lreq` files behave in scripts.
 
 ## Roadmap
 
-- `-v` verbose mode — sent headers, resolved URL, response time
 - Assertions (`A: status = 200`) and a test mode for CI
 - Environment overlays (`VARS dev` / `VARS prod` + `--env`)
 
@@ -220,6 +269,7 @@ Ideas and PRs welcome.
 
 ```sh
 cargo build
+cargo test
 cargo run -- example.lreq --list
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Prefer clicking? There's a [VS Code / Cursor extension](https://github.com/2yuri
 lazyreq <file.lreq> <request-id>          # run a request
 lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
 lazyreq <file.lreq> --list                # list every request in the file
+lazyreq import '<curl command>'           # convert a curl command to a request block
 ```
 
 ```sh
@@ -84,6 +85,21 @@ $ lazyreq api.lreq --list
 login  POST    $baseURL/login
 me     GET     $baseURL/users/me
 ```
+
+### Importing from curl
+
+Paste a curl command (e.g. browser devtools → "Copy as cURL") and get a request block back:
+
+```sh
+$ lazyreq import 'curl "https://api.example.com/v1/users" \
+    -H "Authorization: Bearer tok" -d '\''{"name":"yuri"}'\'''
+ID: users
+POST https://api.example.com/v1/users
+H: Authorization = Bearer tok
+{"name":"yuri"}
+```
+
+Append it to a collection with `lazyreq import '...' >> api.lreq`. Supports `-X`, `-H`, `-d`/`--data*`, `-F` (with `@file` → `file://`), `-u` (→ basic auth header), `-b`, `-A`, `-e` and `--url`; literal `$` in values is escaped automatically.
 
 ## The .lreq format
 
@@ -192,7 +208,6 @@ The exit code is 1 on any error, so `.lreq` files behave in scripts.
 
 ## Roadmap
 
-- `lazyreq import '<curl command>'` — convert a pasted curl (e.g. browser devtools "Copy as cURL") into a request block
 - `-v` verbose mode — sent headers, resolved URL, response time
 - Assertions (`A: status = 200`) and a test mode for CI
 - Environment overlays (`VARS dev` / `VARS prod` + `--env`)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,164 @@
+<p align="center">
+  <img src="logo.png" alt="lazyreq" width="140" />
+</p>
+
+# lazyreq
+
+A lazy, file-based HTTP client for your terminal. Describe your requests once in a plain-text `.lreq` file — with variables, auth hooks, and built-in functions — and run them by name.
+
+```sh
+lazyreq api.lreq login
+```
+
+No GUI, no workspace sync, no JSON exports. Your API collection is a text file that lives in your repo and diffs like code.
+
+## Install
+
+**From a release** — grab a binary for macOS (universal), Linux (x86_64/arm64) or Windows from the [releases page](https://github.com/2yuri/lazyreq/releases) and put it on your `PATH`.
+
+**From source:**
+
+```sh
+cargo install --git https://github.com/2yuri/lazyreq
+```
+
+There is also a [VS Code / Cursor extension](https://github.com/2yuri/lazyreq-vscode) that adds syntax highlighting and ▶ Run / Copy-as-curl buttons to `.lreq` files.
+
+## Usage
+
+```sh
+lazyreq <file.lreq> <request-id>          # run a request
+lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
+lazyreq <file.lreq> --list                # list every request in the file
+```
+
+## The .lreq format
+
+A file has three kinds of sections: `VARS`, `HOOKS`, and one block per request starting with `ID:`.
+
+```lreq
+VARS
+  baseURL = http://localhost:8080
+  path = api/v1
+  # values can come from the environment:
+  apiKey = $env.MY_API_KEY
+
+HOOKS
+  # `login` runs the request with ID `login` and caches its
+  # response for 30 seconds (omit the number to never cache)
+  login = $req.login 30
+
+ID: login
+POST $baseURL/$path/login
+H: Content-Type = application/json
+{
+  "email": "hello@yuri.dev",
+  "password": "hunter2"
+}
+
+ID: me
+GET $baseURL/$path/users/me
+H: Authorization = Bearer $login.token
+```
+
+Running `lazyreq api.lreq me` executes `login` first (or reuses the cached response), extracts `.token` from its JSON, and sends the authenticated request.
+
+### Line types inside a request
+
+| Line | Meaning |
+|---|---|
+| `METHOD url` | `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD` or `OPTIONS` — must come first |
+| `H: Name = value` | a header |
+| `M: name = value` | a multipart form field (sets up `multipart/form-data`) |
+| anything else | accumulated into the request body |
+| `# ...` | comment |
+
+Multipart values have two special prefixes:
+
+```lreq
+M: image = file://./photo.png                 # upload a local file
+M: image = download://https://example.com/a.png   # fetch a URL, upload the bytes
+```
+
+`key = value` lines split on the **first** `=`, so values containing `=` (tokens, base64 signatures) just work. A value wrapped in one pair of `"` or `'` has the quotes stripped.
+
+### Interpolation
+
+Every `$token` below works in URLs, header values and multipart values. Bodies are interpolated too, but **leniently**: an unknown `$word` in a body is left untouched, so JSON like `{"$gte": 5}` keeps working. Use `$$` anywhere for a literal `$`.
+
+| Token | Resolves to |
+|---|---|
+| `$name` | a variable from `VARS` |
+| `$env.NAME` | an environment variable |
+| `$hook.path.to.field` | runs the hook's request, drills into its JSON response |
+| `$body` | the final body of the *current* request (URLs/headers/multipart only) |
+
+### Built-in functions
+
+| Function | Result |
+|---|---|
+| `$uuid()` | a random UUID v4 |
+| `$fuzz_str(len)` | a random alphanumeric string |
+| `$fuzz_int(min, max)` | a random integer, inclusive |
+| `$hmac(data, key, algo?, encoding?)` | HMAC of `data` — `algo`: `sha1`/`sha256`/`sha512` (default `sha256`), `encoding`: `hex`/`base64` (default `base64`) |
+
+Each occurrence is evaluated independently — two `$uuid()` in one body produce two different UUIDs. Function arguments can themselves be variables, `$env.X`, or `$body`.
+
+Signing a webhook body:
+
+```lreq
+ID: webhook
+POST $baseURL/webhook
+H: Content-Type = application/json
+H: X-Signature = $hmac($body, $env.WEBHOOK_SECRET)
+{
+  "event": "user.updated",
+  "id": "$uuid()"
+}
+```
+
+The body is resolved first (fuzz values and all), then `$hmac($body, ...)` signs exactly the bytes that get sent.
+
+### Hooks and caching
+
+```lreq
+HOOKS
+  login = $req.login 30
+```
+
+`$req.<id>` names the request to run; the optional number is a cache TTL in seconds. Cached responses live in `~/.lazyreq/cache/` keyed by (file, request id), so a login token is fetched once and reused until it expires. Without a TTL the hook runs on every use.
+
+### Exporting curl
+
+```sh
+$ lazyreq api.lreq me --curl
+curl -X GET \
+  -H "Authorization: Bearer eyJhbG..." \
+  "http://localhost:8080/api/v1/users/me"
+```
+
+Hooks are resolved during export, so the command is ready to paste. (That also means exporting can hit your auth endpoint — cached per the hook's TTL.)
+
+### Errors
+
+Failures are reported with context, not stack traces:
+
+```
+error: invalid line 14 of api.lreq:
+  H: X-Loop-Signature "abc..."
+  hint: headers use `H: Name = value`
+
+error: request `me` failed:
+  field `token` not found in response of hook `login` (available fields: error)
+```
+
+The exit code is 1 on any error, so `.lreq` files behave in scripts.
+
+## Development
+
+```sh
+cargo build
+cargo run -- example.lreq --list
+```
+
+Releases are cut by pushing a `v*` tag — GitHub Actions cross-compiles all targets with GoReleaser + cargo-zigbuild. PRs get a snapshot build as a smoke test.

--- a/README.md
+++ b/README.md
@@ -2,54 +2,48 @@
   <img src="logo.png" alt="lazyreq" width="140" />
 </p>
 
-# lazyreq
+<h1 align="center">lazyreq</h1>
 
-A lazy, file-based HTTP client for your terminal. Describe your requests once in a plain-text `.lreq` file — with variables, auth hooks, and built-in functions — and run them by name.
+<p align="center">
+  A lazy, file-based HTTP client for your terminal.
+  <br />
+  <a href="https://github.com/2yuri/lazyreq/releases"><img src="https://img.shields.io/github/v/release/2yuri/lazyreq?include_prereleases" alt="release" /></a>
+  <a href="https://github.com/2yuri/lazyreq/actions/workflows/release.yml"><img src="https://github.com/2yuri/lazyreq/actions/workflows/release.yml/badge.svg" alt="build" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license" /></a>
+</p>
+
+Describe your requests once in a plain-text `.lreq` file — with variables, auth hooks, and built-in functions — and run them by name:
 
 ```sh
 lazyreq api.lreq login
 ```
 
-No GUI, no workspace sync, no JSON exports. Your API collection is a text file that lives in your repo and diffs like code.
+**Why lazyreq?**
 
-## Install
+- **Your API collection is a text file.** It lives in your repo, diffs like code, and works in CI. No GUI, no cloud workspace, no JSON exports.
+- **Auth that gets out of the way.** Hooks run your login request automatically, extract the token from its JSON, and cache it — every other request just says `$login.token`.
+- **Sign, fuzz, generate.** Built-in `$hmac()`, `$uuid()`, `$fuzz_str()` and `$fuzz_int()` cover webhook signatures and quick fuzzing without leaving the file.
+- **Escape hatch included.** Any request exports as a ready-to-paste `curl` command.
 
-**From a release** — grab a binary for macOS (universal), Linux (x86_64/arm64) or Windows from the [releases page](https://github.com/2yuri/lazyreq/releases) and put it on your `PATH`.
+## Quick start
 
-**From source:**
+**1.** Install — grab a binary for macOS (universal), Linux (x86_64/arm64) or Windows from the [releases page](https://github.com/2yuri/lazyreq/releases) and put it on your `PATH`, or build with cargo:
 
 ```sh
 cargo install --git https://github.com/2yuri/lazyreq
 ```
 
-There is also a [VS Code / Cursor extension](https://github.com/2yuri/lazyreq-vscode) that adds syntax highlighting and ▶ Run / Copy-as-curl buttons to `.lreq` files.
-
-## Usage
-
-```sh
-lazyreq <file.lreq> <request-id>          # run a request
-lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
-lazyreq <file.lreq> --list                # list every request in the file
-```
-
-## The .lreq format
-
-A file has three kinds of sections: `VARS`, `HOOKS`, and one block per request starting with `ID:`.
+**2.** Create `api.lreq`:
 
 ```lreq
 VARS
   baseURL = http://localhost:8080
-  path = api/v1
-  # values can come from the environment:
-  apiKey = $env.MY_API_KEY
 
 HOOKS
-  # `login` runs the request with ID `login` and caches its
-  # response for 30 seconds (omit the number to never cache)
   login = $req.login 30
 
 ID: login
-POST $baseURL/$path/login
+POST $baseURL/login
 H: Content-Type = application/json
 {
   "email": "hello@yuri.dev",
@@ -57,16 +51,67 @@ H: Content-Type = application/json
 }
 
 ID: me
-GET $baseURL/$path/users/me
+GET $baseURL/users/me
 H: Authorization = Bearer $login.token
 ```
 
-Running `lazyreq api.lreq me` executes `login` first (or reuses the cached response), extracts `.token` from its JSON, and sends the authenticated request.
+**3.** Run it:
 
-### Line types inside a request
+```sh
+$ lazyreq api.lreq me
+[GET] http://localhost:8080/users/me
+Status: 200 OK
+{
+  "id": 42,
+  "email": "hello@yuri.dev"
+}
+```
+
+`login` ran first (and was cached for 30 seconds), its `token` field became the `Authorization` header, and you never typed a token.
+
+Prefer clicking? There's a [VS Code / Cursor extension](https://github.com/2yuri/lazyreq-vscode) with syntax highlighting and ▶ Run / Copy-as-curl buttons.
+
+## CLI
+
+```sh
+lazyreq <file.lreq> <request-id>          # run a request
+lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
+lazyreq <file.lreq> --list                # list every request in the file
+```
+
+```sh
+$ lazyreq api.lreq --list
+login  POST    $baseURL/login
+me     GET     $baseURL/users/me
+```
+
+## The .lreq format
+
+A file has three kinds of sections: `VARS`, `HOOKS`, and one block per request starting with `ID:`.
+
+### VARS
+
+```lreq
+VARS
+  baseURL = http://localhost:8080
+  # values can come from the environment:
+  apiKey = $env.MY_API_KEY
+```
+
+### HOOKS
+
+```lreq
+HOOKS
+  login = $req.login 30
+```
+
+`$req.<id>` names the request to run; the optional number is a cache TTL in seconds. Cached responses live in `~/.lazyreq/cache/` keyed by (file, request id), so a login token is fetched once and reused until it expires. Without a TTL the hook runs on every use.
+
+### Requests
 
 | Line | Meaning |
 |---|---|
+| `ID: name` | starts a request block |
 | `METHOD url` | `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD` or `OPTIONS` — must come first |
 | `H: Name = value` | a header |
 | `M: name = value` | a multipart form field (sets up `multipart/form-data`) |
@@ -76,13 +121,13 @@ Running `lazyreq api.lreq me` executes `login` first (or reuses the cached respo
 Multipart values have two special prefixes:
 
 ```lreq
-M: image = file://./photo.png                 # upload a local file
-M: image = download://https://example.com/a.png   # fetch a URL, upload the bytes
+M: image = file://./photo.png                       # upload a local file
+M: image = download://https://example.com/a.png     # fetch a URL, upload the bytes
 ```
 
 `key = value` lines split on the **first** `=`, so values containing `=` (tokens, base64 signatures) just work. A value wrapped in one pair of `"` or `'` has the quotes stripped.
 
-### Interpolation
+## Interpolation
 
 Every `$token` below works in URLs, header values and multipart values. Bodies are interpolated too, but **leniently**: an unknown `$word` in a body is left untouched, so JSON like `{"$gte": 5}` keeps working. Use `$$` anywhere for a literal `$`.
 
@@ -119,27 +164,18 @@ H: X-Signature = $hmac($body, $env.WEBHOOK_SECRET)
 
 The body is resolved first (fuzz values and all), then `$hmac($body, ...)` signs exactly the bytes that get sent.
 
-### Hooks and caching
-
-```lreq
-HOOKS
-  login = $req.login 30
-```
-
-`$req.<id>` names the request to run; the optional number is a cache TTL in seconds. Cached responses live in `~/.lazyreq/cache/` keyed by (file, request id), so a login token is fetched once and reused until it expires. Without a TTL the hook runs on every use.
-
-### Exporting curl
+## Exporting curl
 
 ```sh
 $ lazyreq api.lreq me --curl
 curl -X GET \
   -H "Authorization: Bearer eyJhbG..." \
-  "http://localhost:8080/api/v1/users/me"
+  "http://localhost:8080/users/me"
 ```
 
 Hooks are resolved during export, so the command is ready to paste. (That also means exporting can hit your auth endpoint — cached per the hook's TTL.)
 
-### Errors
+## Errors
 
 Failures are reported with context, not stack traces:
 
@@ -154,6 +190,15 @@ error: request `me` failed:
 
 The exit code is 1 on any error, so `.lreq` files behave in scripts.
 
+## Roadmap
+
+- `lazyreq import '<curl command>'` — convert a pasted curl (e.g. browser devtools "Copy as cURL") into a request block
+- `-v` verbose mode — sent headers, resolved URL, response time
+- Assertions (`A: status = 200`) and a test mode for CI
+- Environment overlays (`VARS dev` / `VARS prod` + `--env`)
+
+Ideas and PRs welcome.
+
 ## Development
 
 ```sh
@@ -162,3 +207,7 @@ cargo run -- example.lreq --list
 ```
 
 Releases are cut by pushing a `v*` tag — GitHub Actions cross-compiles all targets with GoReleaser + cargo-zigbuild. PRs get a snapshot build as a smoke test.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ lazyreq <file.lreq> <request-id>          # run a request
 lazyreq <file.lreq> <request-id> --curl   # print it as a curl command instead
 lazyreq <file.lreq> --list                # list every request in the file
 lazyreq import '<curl command>'           # convert a curl command to a request block
+lazyreq --version                         # print the CLI version
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -156,6 +156,34 @@ Failed sends (DNS, refused connections, timeouts) are recorded too, with the err
 
 The compact-by-default output is deliberate: list views are one line per run, response bodies are summarized as shapes (`{token: str(212), user: {id: int}}`), and full payloads or headers appear only behind explicit flags (`-v`, `--show-headers`). The agent escalates detail only when it needs it.
 
+### Benchmarks
+
+Measured with [`bench/bench.py`](bench/bench.py): real `curl` and `lazyreq` subprocesses drive a live local API through agent workflows, and everything the agent must **write** (commands) and **read** (output) is counted with tiktoken. Reproduce with `python3 bench/bench.py` (needs `lazyreq` on `PATH`; `pip install tiktoken` for exact counts).
+
+| workflow | curl | lazyreq | savings |
+|---|--:|--:|--:|
+| author the `.lreq` collection (one-time) | 0 | 368 | — |
+| cold start: login + authenticated GET | 563 | 198 | **65%** |
+| repeat the same GET ×5 | 1,605 | 990 | **38%** |
+| new session: recall what an endpoint returns | 1,669 | 157 | **91%** |
+| debug: inspect a failing POST | 658 | 142 | **78%** |
+| reproduce a failed run exactly (fuzzed payload) | 1,007 | 114 | **89%** |
+| send an HMAC-signed webhook | 206 | 42 | **80%** |
+| recover from an expired auth token | 757 | 198 | **74%** |
+| **total** | **6,465** | **2,209** | **66%** |
+
+Weighted by price (generated tokens cost ~5× ingested ones), the overall saving is **76%** — lazyreq's advantage concentrates in the expensive direction: a full authenticated flow is 7 generated tokens instead of 225.
+
+Recall cost is where the design shows most. Asking "what does this endpoint return?" in a fresh session costs curl a re-auth plus the full payload; lazyreq answers from history with a constant-size shape summary:
+
+| response size | curl | lazyreq | savings |
+|---|--:|--:|--:|
+| /orders, 5 items (1.7 KB) | 1,060 | 159 | 85% |
+| /orders, 50 items (16.5 KB) | 6,565 | 159 | 98% |
+| /orders, 200 items (66.5 KB) | 25,015 | **159** | **99%** |
+
+curl's recall grows linearly with the payload; lazyreq's stays flat at 159 tokens. At 200 items, a single curl recall costs more than the entire eight-workflow lazyreq suite — and the one-time authoring cost (368 tokens) is repaid about twice over by the first workflow.
+
 **Skill.** This repo ships a ready-made skill for Claude Code and compatible agents at [`skills/lazyreq/`](skills/lazyreq/) — it teaches the agent the `.lreq` format, the CLI, and the history-first workflow. Install it by copying (or symlinking) the folder:
 
 ```sh
@@ -261,7 +289,7 @@ Failures are reported with context, not stack traces:
 
 ```
 error: invalid line 14 of api.lreq:
-  H: X-Loop-Signature "abc..."
+  H: X-Signature "abc..."
   hint: headers use `H: Name = value`
 
 error: request `me` failed:

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Token-cost benchmark: driving an API as an LLM agent with raw curl vs lazyreq.
+
+Measures the exact text an agent must WRITE (shell commands) and READ
+(command output) to complete realistic workflows, against a live local API.
+All commands actually run. Token counting uses tiktoken when available.
+"""
+import base64
+import hashlib
+import hmac as hmac_mod
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+PORT = 8971
+BASE = f"http://localhost:{PORT}"
+SECRET = "bench-webhook-secret"
+# realistic JWT-sized token so the "auth tax" is honest
+JWT = ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+       "eyJzdWIiOiI0MiIsIm5hbWUiOiJZdXJpIE1pZ3VlbCIsInJvbGVzIjpbImFkbWluIiwiZGV2Il0sImlhdCI6MTc4Mzk4NzYwMSwiZXhwIjoxNzgzOTkxMjAxLCJpc3MiOiJiZW5jaC1hcGkifQ."
+       "3fXk9dQ2mVnB8sLwYtR5uHc1KpZaEoJ7NxG4iD6yTqM")
+STALE_JWT = JWT[:-6] + "EXPIRD"  # same shape, rejected by the server
+
+USER = {
+    "id": 42, "email": "hello@yuri.dev", "name": "Yuri Miguel",
+    "roles": ["admin", "dev"], "verified": True,
+    "created_at": "2023-01-14T09:22:31Z", "last_login": "2026-07-14T00:06:41Z",
+    "preferences": {"theme": "dark", "locale": "pt-BR", "notifications": {"email": True, "push": False}},
+    "shop": {"id": 13733, "name": "Loja do Yuri", "plan": "pro", "region": "sa-east-1"},
+}
+
+
+def orders_payload(n):
+    return {
+        "total": 128, "page": 1, "per_page": n,
+        "items": [
+            {"id": 12300 + i, "shop_id": 13733, "status": ["paid", "pending", "shipped"][i % 3],
+             "amount_cents": 1990 + i * 731, "currency": "BRL",
+             "customer": {"id": 900 + i, "email": f"customer{i}@example.com",
+                          "name": f"Customer Number {i}", "document": f"123.456.789-{i:02d}"},
+             "shipping": {"method": "sedex", "tracking": f"BR{i:09d}XX", "eta_days": 2 + i % 5},
+             "created_at": f"2026-07-{10 + (i % 4):02d}T1{i % 10}:0{i % 6}:00Z"}
+            for i in range(n)
+        ],
+    }
+
+
+class Api(BaseHTTPRequestHandler):
+    def _send(self, obj, status=200):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self):
+        return self.rfile.read(int(self.headers.get("Content-Length", 0)))
+
+    def do_POST(self):
+        if self.path == "/login":
+            self._send({"token": JWT, "token_type": "Bearer", "expires_in": 3600,
+                        "user": {"id": 42, "email": "hello@yuri.dev"}})
+        elif self.path == "/orders":
+            self._body()
+            self._send({"error": "validation_failed",
+                        "details": [{"field": "shop_id", "message": "shop 99999 does not exist"}]}, 422)
+        elif self.path == "/webhook":
+            self._body()
+            self._send({"error": "duplicate_event",
+                        "message": "event with this idempotency key was already processed"}, 409)
+        elif self.path == "/signed-webhook":
+            raw = self._body()
+            expected = base64.b64encode(
+                hmac_mod.new(SECRET.encode(), raw, hashlib.sha256).digest()
+            ).decode()
+            if self.headers.get("X-Signature") != expected:
+                self._send({"error": "invalid_signature"}, 401)
+            else:
+                self._send({"ok": True, "signature": "valid"})
+        else:
+            self._send({"error": "not found"}, 404)
+
+    def do_GET(self):
+        if self.headers.get("Authorization") != f"Bearer {JWT}":
+            self._send({"error": "unauthorized", "message": "token expired or invalid"}, 401)
+            return
+        parsed = urlparse(self.path)
+        if parsed.path == "/users/me":
+            self._send(USER)
+        elif parsed.path == "/orders":
+            n = int(parse_qs(parsed.query).get("n", ["10"])[0])
+            self._send(orders_payload(n))
+        else:
+            self._send({"error": "not found"}, 404)
+
+    def log_message(self, *a):
+        pass
+
+
+def tokens(text):
+    try:
+        import tiktoken
+        return len(tiktoken.get_encoding("o200k_base").encode(text))
+    except Exception:
+        return max(1, round(len(text) / 4))
+
+
+def sh(cmd, env=None):
+    r = subprocess.run(cmd, shell=isinstance(cmd, str), capture_output=True, text=True, env=env)
+    return (r.stdout + r.stderr)
+
+
+class Side:
+    """Accumulates what the agent writes (commands) and reads (outputs)."""
+    def __init__(self):
+        self.write = ""
+        self.read = ""
+
+    def run(self, cmd, env=None, display_cmd=None):
+        out = sh(cmd, env=env)
+        self.write += (display_cmd or (cmd if isinstance(cmd, str) else " ".join(cmd))) + "\n"
+        self.read += out
+        return out
+
+    def note_write(self, text):
+        self.write += text
+
+    def cost(self):
+        return tokens(self.write), tokens(self.read)
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", PORT), Api)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    lazyreq = os.environ.get("LAZYREQ_BIN") or shutil.which("lazyreq")
+    if not lazyreq:
+        sys.exit("lazyreq binary not found")
+
+    workdir = tempfile.mkdtemp(prefix="lreq-bench-")
+    fake_home = tempfile.mkdtemp(prefix="lreq-bench-home-")  # isolated ~/.lazyreq
+    env = {**os.environ, "HOME": fake_home}
+
+    lreq_file = os.path.join(workdir, "api.lreq")
+    LREQ = f"""VARS
+  baseURL = {BASE}
+  webhookSecret = {SECRET}
+
+HOOKS
+  login = $req.login 1
+
+ID: login
+POST $baseURL/login
+H: Content-Type = application/json
+{{"email": "hello@yuri.dev", "password": "hunter2"}}
+
+ID: me
+GET $baseURL/users/me
+H: Authorization = Bearer $login.token
+
+ID: orders
+GET $baseURL/orders
+H: Authorization = Bearer $login.token
+
+ID: orders-5
+GET $baseURL/orders?n=5
+H: Authorization = Bearer $login.token
+
+ID: orders-50
+GET $baseURL/orders?n=50
+H: Authorization = Bearer $login.token
+
+ID: orders-200
+GET $baseURL/orders?n=200
+H: Authorization = Bearer $login.token
+
+ID: create-order
+POST $baseURL/orders
+H: Content-Type = application/json
+H: Authorization = Bearer $login.token
+{{"shop_id": 99999, "amount_cents": 1990}}
+
+ID: webhook
+POST $baseURL/webhook
+H: Content-Type = application/json
+H: Authorization = Bearer $login.token
+{{"event": "order.paid", "idempotency_key": "$uuid()", "nonce": "$fuzz_str(16)", "amount_cents": 1990}}
+
+ID: signed
+POST $baseURL/signed-webhook
+H: Content-Type = application/json
+H: X-Signature = $hmac($body, $webhookSecret)
+{{"event": "order.paid", "order_id": 12312, "shop_id": 13733, "amount_cents": 1990}}
+"""
+    with open(lreq_file, "w") as f:
+        f.write(LREQ)
+
+    curl_login = f"""curl -s -X POST -H "Content-Type: application/json" -d '{{"email": "hello@yuri.dev", "password": "hunter2"}}' "{BASE}/login\""""
+    curl_me = f"""curl -s -H "Authorization: Bearer {JWT}" "{BASE}/users/me\""""
+    curl_me_stale = f"""curl -s -H "Authorization: Bearer {STALE_JWT}" "{BASE}/users/me\""""
+    curl_orders = f"""curl -s -H "Authorization: Bearer {JWT}" "{BASE}/orders\""""
+    curl_create = f"""curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {JWT}" -d '{{"shop_id": 99999, "amount_cents": 1990}}' "{BASE}/orders\""""
+
+    scenarios = []
+
+    # ---- S0: one-time authoring cost ----------------------------------------
+    c, l = Side(), Side()
+    l.note_write(LREQ)
+    scenarios.append(("S0  author the collection (once)", c, l))
+
+    # ---- S1: cold start — authenticate + GET /users/me ----------------------
+    c, l = Side(), Side()
+    c.run(curl_login)
+    c.run(curl_me)
+    l.run(f'{lazyreq} {lreq_file} me', env=env, display_cmd="lazyreq api.lreq me")
+    scenarios.append(("S1  cold start: login + GET /users/me", c, l))
+
+    # ---- S2: the same request, 5 more times ----------------------------------
+    c, l = Side(), Side()
+    for _ in range(5):
+        c.run(curl_me)
+        l.run(f'{lazyreq} {lreq_file} me', env=env, display_cmd="lazyreq api.lreq me")
+    scenarios.append(("S2  repeat GET /users/me ×5", c, l))
+
+    # ---- S3: new session — 'what does /orders return?' -----------------------
+    sh(f'{lazyreq} {lreq_file} orders', env=env)  # previous session
+    c, l = Side(), Side()
+    c.run(curl_login)
+    c.run(curl_orders)
+    l.run(f'{lazyreq} {lreq_file} orders --history --last 1', env=env,
+          display_cmd="lazyreq api.lreq orders --history --last 1")
+    scenarios.append(("S3  new session: recall /orders response", c, l))
+
+    # ---- S4: debugging — 'what did I send when it failed?' -------------------
+    sh(f'{lazyreq} {lreq_file} create-order', env=env)
+    c, l = Side(), Side()
+    c.run(curl_create + " -v", display_cmd=curl_create + " -v")
+    l.run(f'{lazyreq} {lreq_file} create-order --history --failed -v --last 1', env=env,
+          display_cmd="lazyreq api.lreq create-order --history --failed -v --last 1")
+    scenarios.append(("S4  debug: inspect the failing POST", c, l))
+
+    # ---- S5: reproduce a failed run EXACTLY (generated payload) --------------
+    sh(f'{lazyreq} {lreq_file} webhook', env=env)
+    c, l = Side(), Side()
+    webhook_body = ('{"event": "order.paid", "idempotency_key": "9c1b2a4e-77d3-4f0a-9d21-3c5e8b6f0a11", '
+                    '"nonce": "Xk3pQz7LmN2vR8sT", "amount_cents": 1990}')
+    curl_webhook = (f'curl -s -X POST -H "Content-Type: application/json" '
+                    f'-H "Authorization: Bearer {JWT}" -d \'{webhook_body}\' "{BASE}/webhook"')
+    c.run(curl_webhook + " -v", display_cmd=curl_webhook + " -v")  # earlier failing call, verbose
+    c.run(curl_webhook)                                            # reproduction: exact body re-typed
+    out = l.run(f'{lazyreq} {lreq_file} --history --status 409 --last 1', env=env,
+                display_cmd="lazyreq api.lreq --history --status 409 --last 1")
+    run_id = out.split()[0]
+    l.run(f'{lazyreq} {lreq_file} --retry {run_id}', env=env,
+          display_cmd=f"lazyreq api.lreq --retry {run_id}")
+    scenarios.append(("S5  reproduce the failed run exactly", c, l))
+
+    # ---- S6: HMAC-signed webhook ---------------------------------------------
+    c, l = Side(), Side()
+    signed_body = '{"event": "order.paid", "order_id": 12312, "shop_id": 13733, "amount_cents": 1990}'
+    sign_cmd = f"printf '%s' '{signed_body}' | openssl dgst -sha256 -hmac \"{SECRET}\" -binary | base64"
+    digest = c.run(sign_cmd).strip()                               # compute signature, read digest
+    c.run(f'curl -s -X POST -H "Content-Type: application/json" -H "X-Signature: {digest}" '
+          f"-d '{signed_body}' \"{BASE}/signed-webhook\"")         # paste digest into the call
+    l.run(f'{lazyreq} {lreq_file} signed', env=env, display_cmd="lazyreq api.lreq signed")
+    scenarios.append(("S6  send an HMAC-signed webhook", c, l))
+
+    # ---- S7: expired token mid-session ----------------------------------------
+    sh(f'{lazyreq} {lreq_file} me', env=env)   # hook cached with ttl=1...
+    time.sleep(1.2)                            # ...and now it's expired
+    c, l = Side(), Side()
+    c.run(curl_me_stale)                       # 401 with the stale token
+    c.run(curl_login)                          # re-authenticate, read new token
+    c.run(curl_me)                             # re-paste, retry
+    l.run(f'{lazyreq} {lreq_file} me', env=env, display_cmd="lazyreq api.lreq me")
+    scenarios.append(("S7  recover from an expired token", c, l))
+
+    # ---- Report -----------------------------------------------------------------
+    try:
+        import tiktoken  # noqa: F401
+        counter = "tiktoken o200k_base"
+    except Exception:
+        counter = "chars/4 heuristic"
+
+    print(f"\nToken cost per workflow (agent writes + reads), counted with {counter}\n")
+    header = f"{'scenario':<44} {'curl':>7} {'lazyreq':>8} {'savings':>8} {'weighted':>9}"
+    print(header)
+    print("-" * len(header))
+    totals = [0, 0, 0, 0]
+    for name, c, l in scenarios:
+        cw, cr = c.cost()
+        lw, lr = l.cost()
+        ct, lt = cw + cr, lw + lr
+        cwt, lwt = 5 * cw + cr, 5 * lw + lr    # output tokens ≈5× input price
+        totals[0] += ct; totals[1] += lt; totals[2] += cwt; totals[3] += lwt
+        savings = f"{(1 - lt / ct) * 100:+.0f}%" if ct else "n/a"
+        weighted = f"{(1 - lwt / cwt) * 100:+.0f}%" if cwt else "n/a"
+        print(f"{name:<44} {ct:>7} {lt:>8} {savings:>8} {weighted:>9}")
+    print("-" * len(header))
+    print(f"{'TOTAL':<44} {totals[0]:>7} {totals[1]:>8} "
+          f"{(1 - totals[1] / totals[0]) * 100:>+7.0f}% {(1 - totals[3] / totals[2]) * 100:>+8.0f}%")
+
+    print("\nwrite = tokens the agent generates (commands); read = output it must ingest\n")
+    print(f"{'scenario':<44} {'curl w/r':>12} {'lazyreq w/r':>12}")
+    for name, c, l in scenarios:
+        cw, cr = c.cost()
+        lw, lr = l.cost()
+        print(f"{name:<44} {f'{cw}/{cr}':>12} {f'{lw}/{lr}':>12}")
+
+    # ---- Payload-size sweep: recall cost vs response size ------------------------
+    print("\nRecall in a new session vs payload size (S3 shape, larger /orders pages)\n")
+    print(f"{'payload':<22} {'bytes':>8} {'curl':>7} {'lazyreq':>8} {'savings':>8}")
+    for req_id, n in [("orders-5", 5), ("orders-50", 50), ("orders-200", 200)]:
+        sh(f'{lazyreq} {lreq_file} {req_id}', env=env)  # previous session
+        size = len(json.dumps(orders_payload(n)))
+        c, l = Side(), Side()
+        c.run(curl_login)
+        c.run(f'curl -s -H "Authorization: Bearer {JWT}" "{BASE}/orders?n={n}"')
+        l.run(f'{lazyreq} {lreq_file} {req_id} --history --last 1', env=env,
+              display_cmd=f"lazyreq api.lreq {req_id} --history --last 1")
+        ct, lt = sum(c.cost()), sum(l.cost())
+        print(f"{f'/orders ({n} items)':<22} {size:>8} {ct:>7} {lt:>8} {(1 - lt / ct) * 100:>+7.0f}%")
+
+    server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/example.lreq
+++ b/example.lreq
@@ -37,3 +37,18 @@ ID: new
 GET $baseURL/$path/users/$me.id
 H: Content-Type = application/json
 H: Authorization = Bearer $login.token
+# Built-in functions: $uuid(), $fuzz_str(len), $fuzz_int(min, max)
+# and $hmac(data, key, algo?, encoding?) — algo: sha1|sha256|sha512
+# (default sha256), encoding: hex|base64 (default base64).
+# $body resolves to the final request body, so you can sign it.
+# Use $$ for a literal $.
+ID: create-fuzzed
+POST $baseURL/$path/users
+H: Content-Type = application/json
+H: X-Request-Id = $uuid()
+H: X-Signature = $hmac($body, $env.WEBHOOK_SECRET)
+{
+  "name": "$fuzz_str(12)",
+  "age": $fuzz_int(18, 90),
+  "email": "$fuzz_str(8)@example.com"
+}

--- a/skills/lazyreq/SKILL.md
+++ b/skills/lazyreq/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: lazyreq
+description: Author .lreq files and run HTTP requests with the lazyreq CLI. Use when working with .lreq files, testing HTTP APIs via lazyreq, converting curl commands to request collections, or checking past request runs/results via lazyreq history.
+---
+
+# lazyreq
+
+lazyreq is a file-based HTTP client. Requests live in `.lreq` files (variables, auth hooks, signing functions) and run by name. It records every run into an **encrypted local history** you can query — so check history before re-running requests, instead of re-executing them just to see what they return.
+
+## Commands
+
+```sh
+lazyreq <file.lreq> --list                # request ids + methods + urls (start here)
+lazyreq <file.lreq> <id>                  # run a request, print response
+lazyreq <file.lreq> <id> --curl           # print as a curl command (does not run)
+lazyreq import '<curl command>'           # convert curl → .lreq block (append with >>)
+
+# history — past runs, compact by default
+lazyreq <file.lreq> --history             # one line per run (status, latency, size)
+lazyreq <file.lreq> <id> --history        # runs of one request + response JSON shape
+lazyreq <file.lreq> <id> --history -v     # + resolved URL, request body, full response
+lazyreq <file.lreq> --history --failed    # filters: --success | --failed | --status 401
+lazyreq <file.lreq> --history --last 3    # limit to the N most recent
+```
+
+## Workflow
+
+1. **Orient**: `--list` shows what exists; read the `.lreq` file for details.
+2. **Check history first**: `lazyreq api.lreq me --history --last 3` tells you whether a request recently succeeded and what shape its response has — often that answers the question with ~30 tokens, without re-running anything. Never re-run a POST/PUT/DELETE just to recall its response.
+3. **Run** what you need. Every run (including hook-triggered logins) is recorded automatically.
+4. **Debug failures** with `--history --failed -v`: you get the resolved URL and body that were actually sent. Add `--show-headers` only when debugging headers specifically — it prints live auth tokens into your context.
+
+## Authoring .lreq files
+
+Minimal anatomy (full spec: [references/format.md](references/format.md)):
+
+```lreq
+VARS
+  baseURL = http://localhost:8080
+  apiKey = $env.MY_API_KEY        # secrets come from the environment
+
+HOOKS
+  login = $req.login 300           # run `login`, cache its JSON response 300s
+
+ID: login
+POST $baseURL/auth/login
+H: Content-Type = application/json
+{"email": "x@y.z", "password": "$env.PASSWORD"}
+
+ID: me
+DESCRIPTION: Current user
+GET $baseURL/users/me
+H: Authorization = Bearer $login.token   # drills into the hook's JSON response
+```
+
+Rules that matter when generating files:
+
+- `METHOD url` must be the first line after `ID:`/`DESCRIPTION:`. Headers are `H: Name = value`, multipart fields `M: name = value`, everything else becomes the body.
+- `$token` interpolation is **strict** in URLs/headers/multipart (unknown tokens are errors) but **lenient** in bodies (`{"$gte": 5}` passes through). Escape a literal dollar as `$$`.
+- `key = value` splits on the first `=` only; one pair of surrounding quotes is stripped.
+- Functions: `$uuid()`, `$fuzz_str(len)`, `$fuzz_int(min, max)`, `$hmac(data, key, algo?, encoding?)`. `$body` (URLs/headers only) is the final interpolated body — `H: X-Signature = $hmac($body, $env.SECRET)` signs exactly what is sent.
+- Never hardcode secrets in the file; use `$env.X`.
+
+Judgment calls:
+
+- **Auth chain** → a `login` request + a hook with a TTL slightly shorter than the token's lifetime; consumers write `$login.token`.
+- **Converting docs or devtools output** → prefer `lazyreq import 'curl ...'` over hand-writing, then replace literal hosts/tokens with `$vars` and `$env.X`.
+- **After editing a file** → `lazyreq file.lreq --list` is a cheap parse check; errors carry line numbers and hints.
+
+## Hard rules
+
+- Never read or write files under `~/.lazyreq/` directly — they are encrypted (gzip + XChaCha20-Poly1305; key in `~/.lazyreq/key`, overridable via `LAZYREQ_KEY`). The only interface is the CLI.
+- Never re-run mutating requests to recover information that `--history` already has.
+- `--curl` still resolves hooks, so it can hit the auth endpoint; it does not run the request itself and records no history for it.

--- a/skills/lazyreq/SKILL.md
+++ b/skills/lazyreq/SKILL.md
@@ -15,12 +15,16 @@ lazyreq <file.lreq> <id>                  # run a request, print response
 lazyreq <file.lreq> <id> --curl           # print as a curl command (does not run)
 lazyreq import '<curl command>'           # convert curl → .lreq block (append with >>)
 
-# history — past runs, compact by default
-lazyreq <file.lreq> --history             # one line per run (status, latency, size)
+# history — past runs, compact by default; first column is the run id
+lazyreq <file.lreq> --history             # one line per run (run id, status, latency, size)
 lazyreq <file.lreq> <id> --history        # runs of one request + response JSON shape
 lazyreq <file.lreq> <id> --history -v     # + resolved URL, request body, full response
+lazyreq <file.lreq> --history --req <run-id> -v  # one specific run, fully detailed
 lazyreq <file.lreq> --history --failed    # filters: --success | --failed | --status 401
 lazyreq <file.lreq> --history --last 3    # limit to the N most recent
+
+# retry — replay a recorded run by its run id
+lazyreq <file.lreq> --retry <run-id>      # exact recorded URL+body, fresh headers/auth
 ```
 
 ## Workflow
@@ -28,7 +32,8 @@ lazyreq <file.lreq> --history --last 3    # limit to the N most recent
 1. **Orient**: `--list` shows what exists; read the `.lreq` file for details.
 2. **Check history first**: `lazyreq api.lreq me --history --last 3` tells you whether a request recently succeeded and what shape its response has — often that answers the question with ~30 tokens, without re-running anything. Never re-run a POST/PUT/DELETE just to recall its response.
 3. **Run** what you need. Every run (including hook-triggered logins) is recorded automatically.
-4. **Debug failures** with `--history --failed -v`: you get the resolved URL and body that were actually sent. Add `--show-headers` only when debugging headers specifically — it prints live auth tokens into your context.
+4. **Debug failures** with `--history --failed -v`: you get the resolved URL and body that were actually sent, plus each run's id. Add `--show-headers` only when debugging headers specifically — it prints live auth tokens into your context.
+5. **Reproduce exactly** with `--retry <run-id>`: replays the recorded body byte-for-byte (generated `$uuid()`/`$fuzz_*()` values included — a normal re-run would regenerate them) while re-resolving headers so auth is fresh and `$hmac($body, ...)` is recomputed. Never hand-rebuild a curl command from `-v` output to reproduce a request. Retrying re-executes the request — for POST/PUT/DELETE that mutates state, so retry deliberately, not to recall information.
 
 ## Authoring .lreq files
 

--- a/skills/lazyreq/references/format.md
+++ b/skills/lazyreq/references/format.md
@@ -1,0 +1,89 @@
+# The .lreq format — full reference
+
+A `.lreq` file has three kinds of sections: `VARS`, `HOOKS`, and one block per request starting with `ID:`. Blank lines are ignored; `#` at the start of a line is a comment.
+
+## VARS
+
+```lreq
+VARS
+  baseURL = http://localhost:8080
+  apiKey = $env.MY_API_KEY
+```
+
+- `name = value` pairs. Values may be `$env.VAR_NAME` (resolved at parse time; missing env var = error).
+- One pair of surrounding `"` or `'` quotes is stripped; inner quotes survive.
+
+## HOOKS
+
+```lreq
+HOOKS
+  login = $req.login 300
+  me = $req.me
+```
+
+- `name = $req.<request-id> [ttl-seconds]`. Using `$name.field` anywhere executes that request and drills into its JSON response (`$login.token`, `$login.user.id`).
+- With a TTL, the response is cached (encrypted) under `~/.lazyreq/cache/`, keyed by the file's absolute path + request id. Without a TTL the hook runs on every use.
+- A hook whose request returns non-2xx is an error.
+- Hooks may reference other hooks; recursion depth is capped at 16.
+
+## Requests
+
+```lreq
+ID: create-user
+DESCRIPTION: Create a user with a signed payload
+POST $baseURL/users
+H: Content-Type = application/json
+H: X-Request-Id = $uuid()
+H: X-Signature = $hmac($body, $env.SECRET)
+M: avatar = file://./photo.png
+{"name": "$fuzz_str(8)"}
+```
+
+| Line | Meaning |
+|---|---|
+| `ID: name` | starts a request block; ids must be unique in the file |
+| `DESCRIPTION: text` | optional; shown by `--list` |
+| `METHOD url` | `GET`/`POST`/`PUT`/`DELETE`/`PATCH`/`HEAD`/`OPTIONS`; must come before headers refer to the body |
+| `H: Name = value` | header |
+| `M: name = value` | multipart form field (switches the request to `multipart/form-data`) |
+| anything else | accumulated into the request body |
+
+Multipart value prefixes: `file://path` uploads a local file; `download://url` fetches the URL at runtime and uploads the bytes. With multipart, any explicit `Content-Type` header is dropped (the boundary is set automatically).
+
+`key = value` lines split on the **first** `=` only, so values containing `=` (base64, signatures) work. Keys must be a single bare word (`[A-Za-z0-9_-]+`).
+
+## Interpolation
+
+| Token | Resolves to | Where |
+|---|---|---|
+| `$name` | variable from `VARS` | everywhere |
+| `$env.NAME` | environment variable | everywhere |
+| `$hook.path.to.field` | runs the hook's request, drills into its JSON | everywhere |
+| `$body` | the final interpolated body of the current request | URLs, headers, multipart values only |
+| `$$` | a literal `$` | everywhere |
+
+- **Strict contexts** (URL, header values, multipart values): unknown `$tokens` are errors.
+- **Lenient context** (bodies): unknown `$tokens` pass through untouched, so MongoDB-style `{"$gte": 5}` works.
+- Resolution order per request: body first (lenient), then URL/headers/multipart (strict, with `$body` available). This is what makes body signing correct.
+
+## Built-in functions
+
+| Function | Result |
+|---|---|
+| `$uuid()` | random UUID v4 |
+| `$fuzz_str(len)` | random alphanumeric string of `len` chars |
+| `$fuzz_int(min, max)` | random integer, inclusive |
+| `$hmac(data, key, algo?, encoding?)` | HMAC; `algo`: `sha1`/`sha256`/`sha512` (default `sha256`); `encoding`: `hex`/`base64` (default `base64`) |
+
+Each occurrence evaluates independently (two `$uuid()` = two UUIDs). Arguments may themselves be `$vars`, `$env.X` or `$body`.
+
+## History & storage
+
+- Every executed request — including hook-triggered ones — appends an encrypted record (timestamp, id, method, resolved URL, request headers/body, status, latency, response body) under `~/.lazyreq/history/`, keyed by the file's absolute path. Transport failures are recorded too (status `ERR` + the error message).
+- The newest 20 runs per request id are kept.
+- `--curl` and `--list` execute nothing and record nothing.
+- Everything under `~/.lazyreq/` (cache + history) is gzipped then encrypted with XChaCha20-Poly1305. The key is auto-generated at `~/.lazyreq/key` (0600); setting `LAZYREQ_KEY` overrides it. Files written under one key are unreadable (treated as empty) under another.
+
+## Errors
+
+Parse errors carry the file, line number and a hint; runtime errors name the request and hook chain. Exit code is 1 on any error.

--- a/skills/lazyreq/references/format.md
+++ b/skills/lazyreq/references/format.md
@@ -79,7 +79,8 @@ Each occurrence evaluates independently (two `$uuid()` = two UUIDs). Arguments m
 
 ## History & storage
 
-- Every executed request — including hook-triggered ones — appends an encrypted record (timestamp, id, method, resolved URL, request headers/body, status, latency, response body) under `~/.lazyreq/history/`, keyed by the file's absolute path. Transport failures are recorded too (status `ERR` + the error message).
+- Every executed request — including hook-triggered ones — appends an encrypted record (run id, timestamp, request id, method, resolved URL, request headers/body, status, latency, response body) under `~/.lazyreq/history/`, keyed by the file's absolute path. Transport failures are recorded too (status `ERR` + the error message).
+- Each run has a unique 8-hex-char **run id** (first column of `--history` output), distinct from the request's `ID:` name. `--history --req <run-id>` addresses one run; `--retry <run-id>` replays one: recorded URL + body verbatim, headers re-resolved from the current definition (fresh auth, recomputed `$hmac($body, ...)`). Retries are recorded as new runs. Multipart requests cannot be retried (file contents aren't stored).
 - The newest 20 runs per request id are kept.
 - `--curl` and `--list` execute nothing and record nothing.
 - Everything under `~/.lazyreq/` (cache + history) is gzipped then encrypted with XChaCha20-Poly1305. The key is auto-generated at `~/.lazyreq/key` (0600); setting `LAZYREQ_KEY` overrides it. Files written under one key are unreadable (treated as empty) under another.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@ use crate::timest::{add_seconds, get_timestamp, is_older_than};
 use std::fs::{self, File, OpenOptions};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{self, BufRead, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct Cache {
     file: File,
@@ -15,68 +15,52 @@ fn calculate_cache_name(filename: &str, req_id: &str) -> String {
     filename.hash(&mut hasher);
     req_id.hash(&mut hasher);
 
-    return format!("{:x}", hasher.finish());
+    format!("{:x}", hasher.finish())
 }
 
-fn get_lazyreq_dir() -> PathBuf {
-    home::home_dir()
-        .expect("Failed to retrieve home directory")
+fn cache_dir() -> Result<PathBuf, String> {
+    let dir = home::home_dir()
+        .ok_or("cannot determine home directory for the cache".to_string())?
         .join(".lazyreq")
-}
+        .join("cache");
 
-fn setup_directories() -> std::io::Result<PathBuf> {
-    let base_dir = get_lazyreq_dir();
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("cannot create cache directory `{}`: {}", dir.display(), e))?;
 
-    let cache_dir = base_dir.join("cache");
-    fs::create_dir_all(&cache_dir)?;
-
-    Ok(base_dir)
-}
-
-fn find_file(filename: &str, req_id: &str) -> (bool, File) {
-    let cache_name = calculate_cache_name(filename, req_id);
-
-    let path: String = get_lazyreq_dir().to_string_lossy().to_string() + "/cache";
-    let cache_file = format!("{}/{}", path.clone(), cache_name);
-
-    if Path::new(&cache_file).exists() {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(cache_file)
-            .unwrap();
-
-        return (false, file);
-    }
-
-    match setup_directories() {
-        Ok(_) => {}
-        Err(e) => panic!("Failed to set up directories: {}", e),
-    }
-
-    return (true, File::create_new(&cache_file).unwrap());
+    Ok(dir)
 }
 
 impl Cache {
-    pub fn new(filename: &str, req_id: &str) -> Cache {
-        let (is_new, f) = find_file(filename, req_id);
-        if is_new {
-            return Cache {
-                file: f,
+    pub fn new(filename: &str, req_id: &str) -> Result<Cache, String> {
+        let path = cache_dir()?.join(calculate_cache_name(filename, req_id));
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .map_err(|e| format!("cannot open cache file `{}`: {}", path.display(), e))?;
+
+        // A missing or malformed cache file just means "no cached value".
+        let reader = io::BufReader::new(file.try_clone().map_err(|e| e.to_string())?);
+        let mut lines = reader.lines();
+        let expire = lines
+            .next()
+            .and_then(|l| l.ok())
+            .and_then(|l| l.parse::<u64>().ok());
+        let data = lines.next().and_then(|l| l.ok());
+
+        match (expire, data) {
+            (Some(expire), Some(data)) => Ok(Cache {
+                file,
+                data: Some(data),
+                expire,
+            }),
+            _ => Ok(Cache {
+                file,
                 data: None,
                 expire: 0,
-            };
-        }
-
-        let reader = io::BufReader::new(f.try_clone().unwrap());
-        let mut lines = reader.lines();
-        let first_line = lines.next().unwrap();
-        let second_line = lines.next().unwrap();
-
-        Cache {
-            file: f,
-            data: Some(second_line.unwrap().to_string()),
-            expire: first_line.unwrap().to_string().parse::<u64>().unwrap(),
+            }),
         }
     }
 
@@ -89,16 +73,19 @@ impl Cache {
             return self.data.clone();
         }
 
-        return None;
+        None
     }
 
-    pub fn set(&mut self, value: String, expire_in_seconds: u64) {
+    pub fn set(&mut self, value: String, expire_in_seconds: u64) -> Result<(), String> {
         let expired_at = add_seconds(get_timestamp(), expire_in_seconds);
 
-        self.file.set_len(0).unwrap();
-        self.file.seek(SeekFrom::Start(0)).unwrap();
-        self.file
-            .write_all(format!("{}\n{}\n", expired_at, value).as_bytes())
-            .unwrap();
+        let mut write = || -> io::Result<()> {
+            self.file.set_len(0)?;
+            self.file.seek(SeekFrom::Start(0))?;
+            self.file
+                .write_all(format!("{}\n{}\n", expired_at, value).as_bytes())
+        };
+
+        write().map_err(|e| format!("cannot write cache: {}", e))
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,28 +1,16 @@
 use crate::timest::{add_seconds, get_timestamp, is_older_than};
-use std::fs::{self, File, OpenOptions};
-use std::hash::{DefaultHasher, Hash, Hasher};
-use std::io::{self, BufRead, Seek, SeekFrom, Write};
+use crate::vault;
+use std::fs;
 use std::path::PathBuf;
 
 pub struct Cache {
-    file: File,
+    path: PathBuf,
     pub data: Option<String>,
     pub expire: u64,
 }
 
-fn calculate_cache_name(filename: &str, req_id: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    filename.hash(&mut hasher);
-    req_id.hash(&mut hasher);
-
-    format!("{:x}", hasher.finish())
-}
-
 fn cache_dir() -> Result<PathBuf, String> {
-    let dir = home::home_dir()
-        .ok_or("cannot determine home directory for the cache".to_string())?
-        .join(".lazyreq")
-        .join("cache");
+    let dir = vault::lazyreq_dir()?.join("cache");
 
     fs::create_dir_all(&dir)
         .map_err(|e| format!("cannot create cache directory `{}`: {}", dir.display(), e))?;
@@ -32,32 +20,27 @@ fn cache_dir() -> Result<PathBuf, String> {
 
 impl Cache {
     pub fn new(filename: &str, req_id: &str) -> Result<Cache, String> {
-        let path = cache_dir()?.join(calculate_cache_name(filename, req_id));
+        let path = cache_dir()?.join(vault::file_id(filename, req_id));
 
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)
-            .map_err(|e| format!("cannot open cache file `{}`: {}", path.display(), e))?;
+        // A missing, plaintext (pre-encryption) or malformed cache file just
+        // means "no cached value".
+        let entry = fs::read(&path)
+            .ok()
+            .and_then(|bytes| vault::open(&bytes))
+            .and_then(|plain| String::from_utf8(plain).ok())
+            .and_then(|text| {
+                let (expire, data) = text.split_once('\n')?;
+                Some((expire.parse::<u64>().ok()?, data.to_string()))
+            });
 
-        // A missing or malformed cache file just means "no cached value".
-        let reader = io::BufReader::new(file.try_clone().map_err(|e| e.to_string())?);
-        let mut lines = reader.lines();
-        let expire = lines
-            .next()
-            .and_then(|l| l.ok())
-            .and_then(|l| l.parse::<u64>().ok());
-        let data = lines.next().and_then(|l| l.ok());
-
-        match (expire, data) {
-            (Some(expire), Some(data)) => Ok(Cache {
-                file,
+        match entry {
+            Some((expire, data)) => Ok(Cache {
+                path,
                 data: Some(data),
                 expire,
             }),
-            _ => Ok(Cache {
-                file,
+            None => Ok(Cache {
+                path,
                 data: None,
                 expire: 0,
             }),
@@ -79,13 +62,7 @@ impl Cache {
     pub fn set(&mut self, value: String, expire_in_seconds: u64) -> Result<(), String> {
         let expired_at = add_seconds(get_timestamp(), expire_in_seconds);
 
-        let mut write = || -> io::Result<()> {
-            self.file.set_len(0)?;
-            self.file.seek(SeekFrom::Start(0))?;
-            self.file
-                .write_all(format!("{}\n{}\n", expired_at, value).as_bytes())
-        };
-
-        write().map_err(|e| format!("cannot write cache: {}", e))
+        let sealed = vault::seal(format!("{}\n{}", expired_at, value).as_bytes())?;
+        fs::write(&self.path, sealed).map_err(|e| format!("cannot write cache: {}", e))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,24 @@ pub enum Mode {
     Run,
     ExportCurl,
     List,
+    History(HistoryOpts),
     Import(String),
     Version,
+}
+
+#[derive(PartialEq)]
+pub enum HistoryFilter {
+    All,
+    Success,
+    Failed,
+    Status(u16),
+}
+
+pub struct HistoryOpts {
+    pub last: Option<usize>,
+    pub verbose: bool,
+    pub show_headers: bool,
+    pub filter: HistoryFilter,
 }
 
 pub struct Config {
@@ -14,6 +30,7 @@ pub struct Config {
 
 const USAGE: &str = "usage: lazyreq <file.lreq> <request-id> [--curl]
        lazyreq <file.lreq> --list
+       lazyreq <file.lreq> [request-id] --history [--last N] [-v] [--show-headers] [--success|--failed|--status CODE]
        lazyreq import '<curl command>'";
 
 impl Config {
@@ -45,11 +62,59 @@ impl Config {
         let mut filename = String::new();
         let mut target = String::new();
 
-        for arg in args.iter().skip(1) {
+        let mut history = false;
+        let mut opts = HistoryOpts {
+            last: None,
+            verbose: false,
+            show_headers: false,
+            filter: HistoryFilter::All,
+        };
+
+        let mut iter = args.iter().skip(1);
+        while let Some(arg) = iter.next() {
+            let mut value_of = |flag: &str| -> Result<String, String> {
+                iter.next()
+                    .cloned()
+                    .ok_or(format!("`{}` needs a value\n{}", flag, USAGE))
+            };
+            let set_filter = |current: &mut HistoryFilter, new: HistoryFilter| {
+                if *current != HistoryFilter::All {
+                    return Err(format!(
+                        "--success, --failed and --status are mutually exclusive\n{}",
+                        USAGE
+                    ));
+                }
+                *current = new;
+                Ok(())
+            };
+
             if arg == "--curl" {
                 mode = Mode::ExportCurl;
             } else if arg == "--list" {
                 mode = Mode::List;
+            } else if arg == "--history" {
+                history = true;
+            } else if arg == "--last" {
+                let raw = value_of("--last")?;
+                opts.last = Some(raw.parse().map_err(|_| {
+                    format!("invalid value `{}` for --last (expected a number)\n{}", raw, USAGE)
+                })?);
+            } else if arg == "--status" {
+                let raw = value_of("--status")?;
+                let code = raw.parse().map_err(|_| {
+                    format!("invalid value `{}` for --status (expected e.g. 401)\n{}", raw, USAGE)
+                })?;
+                set_filter(&mut opts.filter, HistoryFilter::Status(code))?;
+            } else if arg == "--success" {
+                set_filter(&mut opts.filter, HistoryFilter::Success)?;
+            } else if arg == "--failed" {
+                set_filter(&mut opts.filter, HistoryFilter::Failed)?;
+            } else if arg == "-v" || arg == "--verbose" {
+                opts.verbose = true;
+            } else if arg == "--show-headers" {
+                // seeing headers only makes sense in the detailed view
+                opts.show_headers = true;
+                opts.verbose = true;
             } else if arg.starts_with("--") {
                 return Err(format!("unknown flag `{}`\n{}", arg, USAGE));
             } else if filename.is_empty() {
@@ -61,6 +126,25 @@ impl Config {
             }
         }
 
+        if history {
+            if !matches!(mode, Mode::Run) {
+                return Err(format!(
+                    "--history cannot be combined with --curl or --list\n{}",
+                    USAGE
+                ));
+            }
+            mode = Mode::History(opts);
+        } else if opts.last.is_some()
+            || opts.verbose
+            || opts.show_headers
+            || opts.filter != HistoryFilter::All
+        {
+            return Err(format!(
+                "--last, --status, --success, --failed, -v and --show-headers only work with --history\n{}",
+                USAGE
+            ));
+        }
+
         if filename.is_empty() {
             return Err(USAGE.to_string());
         }
@@ -69,7 +153,7 @@ impl Config {
             return Err(format!("`{}` is not a .lreq file\n{}", filename, USAGE));
         }
 
-        if target.is_empty() && !matches!(mode, Mode::List) {
+        if target.is_empty() && !matches!(mode, Mode::List | Mode::History(_)) {
             return Err(format!("missing request id\n{}", USAGE));
         }
 
@@ -78,5 +162,103 @@ impl Config {
             target,
             mode,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<Config, String> {
+        let mut full = vec!["lazyreq".to_string()];
+        full.extend(args.iter().map(|s| s.to_string()));
+        Config::new(&full)
+    }
+
+    #[test]
+    fn run_mode() {
+        let config = parse(&["api.lreq", "login"]).unwrap();
+        assert!(matches!(config.mode, Mode::Run));
+        assert_eq!(config.filename, "api.lreq");
+        assert_eq!(config.target, "login");
+    }
+
+    #[test]
+    fn run_requires_a_request_id_but_list_and_history_do_not() {
+        assert!(parse(&["api.lreq"]).is_err());
+        assert!(parse(&["api.lreq", "--list"]).is_ok());
+        assert!(parse(&["api.lreq", "--history"]).is_ok());
+    }
+
+    #[test]
+    fn history_flags() {
+        let config = parse(&[
+            "api.lreq", "login", "--history", "--last", "3", "--failed", "-v",
+        ])
+        .unwrap();
+        assert_eq!(config.target, "login");
+        match config.mode {
+            Mode::History(opts) => {
+                assert_eq!(opts.last, Some(3));
+                assert!(opts.verbose);
+                assert!(!opts.show_headers);
+                assert!(opts.filter == HistoryFilter::Failed);
+            }
+            _ => panic!("expected history mode"),
+        }
+    }
+
+    #[test]
+    fn show_headers_implies_verbose() {
+        let config = parse(&["api.lreq", "--history", "--show-headers"]).unwrap();
+        match config.mode {
+            Mode::History(opts) => assert!(opts.verbose && opts.show_headers),
+            _ => panic!("expected history mode"),
+        }
+    }
+
+    #[test]
+    fn status_filter_parses_a_code() {
+        let config = parse(&["api.lreq", "--history", "--status", "401"]).unwrap();
+        match config.mode {
+            Mode::History(opts) => assert!(opts.filter == HistoryFilter::Status(401)),
+            _ => panic!("expected history mode"),
+        }
+        assert!(parse(&["api.lreq", "--history", "--status", "teapot"]).is_err());
+        assert!(parse(&["api.lreq", "--history", "--status"]).is_err());
+    }
+
+    #[test]
+    fn history_filters_are_mutually_exclusive() {
+        assert!(parse(&["api.lreq", "--history", "--success", "--failed"]).is_err());
+        assert!(parse(&["api.lreq", "--history", "--failed", "--status", "500"]).is_err());
+    }
+
+    #[test]
+    fn history_flags_require_history_mode() {
+        assert!(parse(&["api.lreq", "login", "--last", "3"]).is_err());
+        assert!(parse(&["api.lreq", "login", "-v"]).is_err());
+        assert!(parse(&["api.lreq", "login", "--failed"]).is_err());
+    }
+
+    #[test]
+    fn history_rejects_other_modes_and_unknown_flags() {
+        assert!(parse(&["api.lreq", "--history", "--curl"]).is_err());
+        assert!(parse(&["api.lreq", "--history", "--list"]).is_err());
+        assert!(parse(&["api.lreq", "login", "--nope"]).is_err());
+    }
+
+    #[test]
+    fn non_lreq_files_are_rejected() {
+        assert!(parse(&["api.yaml", "login"]).is_err());
+    }
+
+    #[test]
+    fn import_and_version_still_short_circuit() {
+        assert!(matches!(
+            parse(&["import", "curl", "https://x.dev"]).unwrap().mode,
+            Mode::Import(_)
+        ));
+        assert!(matches!(parse(&["--version"]).unwrap().mode, Mode::Version));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ pub enum Mode {
     ExportCurl,
     List,
     History(HistoryOpts),
+    Retry(String),
     Import(String),
     Version,
 }
@@ -20,6 +21,8 @@ pub struct HistoryOpts {
     pub verbose: bool,
     pub show_headers: bool,
     pub filter: HistoryFilter,
+    /// Address a single run by its run id.
+    pub req: Option<String>,
 }
 
 pub struct Config {
@@ -30,7 +33,8 @@ pub struct Config {
 
 const USAGE: &str = "usage: lazyreq <file.lreq> <request-id> [--curl]
        lazyreq <file.lreq> --list
-       lazyreq <file.lreq> [request-id] --history [--last N] [-v] [--show-headers] [--success|--failed|--status CODE]
+       lazyreq <file.lreq> [request-id] --history [--last N] [-v] [--show-headers] [--req RUN-ID] [--success|--failed|--status CODE]
+       lazyreq <file.lreq> --retry <run-id>
        lazyreq import '<curl command>'";
 
 impl Config {
@@ -63,11 +67,13 @@ impl Config {
         let mut target = String::new();
 
         let mut history = false;
+        let mut retry: Option<String> = None;
         let mut opts = HistoryOpts {
             last: None,
             verbose: false,
             show_headers: false,
             filter: HistoryFilter::All,
+            req: None,
         };
 
         let mut iter = args.iter().skip(1);
@@ -94,6 +100,10 @@ impl Config {
                 mode = Mode::List;
             } else if arg == "--history" {
                 history = true;
+            } else if arg == "--retry" {
+                retry = Some(value_of("--retry")?);
+            } else if arg == "--req" {
+                opts.req = Some(value_of("--req")?);
             } else if arg == "--last" {
                 let raw = value_of("--last")?;
                 opts.last = Some(raw.parse().map_err(|_| {
@@ -127,9 +137,9 @@ impl Config {
         }
 
         if history {
-            if !matches!(mode, Mode::Run) {
+            if !matches!(mode, Mode::Run) || retry.is_some() {
                 return Err(format!(
-                    "--history cannot be combined with --curl or --list\n{}",
+                    "--history cannot be combined with --curl, --list or --retry\n{}",
                     USAGE
                 ));
             }
@@ -137,12 +147,27 @@ impl Config {
         } else if opts.last.is_some()
             || opts.verbose
             || opts.show_headers
+            || opts.req.is_some()
             || opts.filter != HistoryFilter::All
         {
             return Err(format!(
-                "--last, --status, --success, --failed, -v and --show-headers only work with --history\n{}",
+                "--last, --status, --success, --failed, --req, -v and --show-headers only work with --history\n{}",
                 USAGE
             ));
+        } else if let Some(run_id) = retry {
+            if !matches!(mode, Mode::Run) {
+                return Err(format!(
+                    "--retry cannot be combined with --curl or --list\n{}",
+                    USAGE
+                ));
+            }
+            if !target.is_empty() {
+                return Err(format!(
+                    "--retry replays a run id, not a request id — drop `{}`\n{}",
+                    target, USAGE
+                ));
+            }
+            mode = Mode::Retry(run_id);
         }
 
         if filename.is_empty() {
@@ -153,7 +178,7 @@ impl Config {
             return Err(format!("`{}` is not a .lreq file\n{}", filename, USAGE));
         }
 
-        if target.is_empty() && !matches!(mode, Mode::List | Mode::History(_)) {
+        if target.is_empty() && !matches!(mode, Mode::List | Mode::History(_) | Mode::Retry(_)) {
             return Err(format!("missing request id\n{}", USAGE));
         }
 
@@ -246,6 +271,27 @@ mod tests {
         assert!(parse(&["api.lreq", "--history", "--curl"]).is_err());
         assert!(parse(&["api.lreq", "--history", "--list"]).is_err());
         assert!(parse(&["api.lreq", "login", "--nope"]).is_err());
+    }
+
+    #[test]
+    fn req_addresses_a_run_within_history() {
+        let config = parse(&["api.lreq", "--history", "--req", "a3f2c1d0"]).unwrap();
+        match config.mode {
+            Mode::History(opts) => assert_eq!(opts.req.as_deref(), Some("a3f2c1d0")),
+            _ => panic!("expected history mode"),
+        }
+        assert!(parse(&["api.lreq", "login", "--req", "a3f2c1d0"]).is_err()); // needs --history
+    }
+
+    #[test]
+    fn retry_takes_a_run_id_and_nothing_else() {
+        let config = parse(&["api.lreq", "--retry", "a3f2c1d0"]).unwrap();
+        assert!(matches!(config.mode, Mode::Retry(id) if id == "a3f2c1d0"));
+
+        assert!(parse(&["api.lreq", "--retry"]).is_err()); // missing value
+        assert!(parse(&["api.lreq", "login", "--retry", "a3f2c1d0"]).is_err()); // no request id
+        assert!(parse(&["api.lreq", "--retry", "a3f2c1d0", "--history"]).is_err());
+        assert!(parse(&["api.lreq", "--retry", "a3f2c1d0", "--curl"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,39 +1,59 @@
+pub enum Mode {
+    Run,
+    ExportCurl,
+    List,
+}
+
 pub struct Config {
     pub filename: String,
     pub target: String,
-    pub export_curl: bool,
+    pub mode: Mode,
 }
 
-impl Config {
-    pub fn new(args: &[String]) -> Config {
-        if args.len() < 3 {
-            panic!("not enough arguments");
-        }
+const USAGE: &str = "usage: lazyreq <file.lreq> <request-id> [--curl]
+       lazyreq <file.lreq> --list";
 
-        let mut export_curl = false;
+impl Config {
+    pub fn new(args: &[String]) -> Result<Config, String> {
+        let mut mode = Mode::Run;
         let mut filename = String::new();
         let mut target = String::new();
 
-        let mut i = 1;
-        while i < args.len() {
-            if args[i] == "--curl" {
-                export_curl = true;
+        for arg in args.iter().skip(1) {
+            if arg == "--curl" {
+                mode = Mode::ExportCurl;
+            } else if arg == "--list" {
+                mode = Mode::List;
+            } else if arg.starts_with("--") {
+                return Err(format!("unknown flag `{}`\n{}", arg, USAGE));
             } else if filename.is_empty() {
-                filename = args[i].clone();
+                filename = arg.clone();
             } else if target.is_empty() {
-                target = args[i].clone();
+                target = arg.clone();
+            } else {
+                return Err(format!("unexpected argument `{}`\n{}", arg, USAGE));
             }
-            i += 1;
         }
 
-        if filename.is_empty() || target.is_empty() {
-            panic!("invalid arguments");
+        if filename.is_empty() {
+            return Err(USAGE.to_string());
         }
 
         if !filename.ends_with(".lreq") {
-            panic!("invalid filename provided");
+            return Err(format!(
+                "`{}` is not a .lreq file\n{}",
+                filename, USAGE
+            ));
         }
 
-        Config { filename, target, export_curl }
+        if target.is_empty() && !matches!(mode, Mode::List) {
+            return Err(format!("missing request id\n{}", USAGE));
+        }
+
+        Ok(Config {
+            filename,
+            target,
+            mode,
+        })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ pub enum Mode {
     ExportCurl,
     List,
     Import(String),
+    Version,
 }
 
 pub struct Config {
@@ -17,6 +18,14 @@ const USAGE: &str = "usage: lazyreq <file.lreq> <request-id> [--curl]
 
 impl Config {
     pub fn new(args: &[String]) -> Result<Config, String> {
+        if args.iter().any(|a| a == "--version" || a == "-V") {
+            return Ok(Config {
+                filename: String::new(),
+                target: String::new(),
+                mode: Mode::Version,
+            });
+        }
+
         if args.get(1).map(|s| s.as_str()) == Some("import") {
             let command = args[2..].join(" ");
             if command.trim().is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ pub enum Mode {
     Run,
     ExportCurl,
     List,
+    Import(String),
 }
 
 pub struct Config {
@@ -11,10 +12,26 @@ pub struct Config {
 }
 
 const USAGE: &str = "usage: lazyreq <file.lreq> <request-id> [--curl]
-       lazyreq <file.lreq> --list";
+       lazyreq <file.lreq> --list
+       lazyreq import '<curl command>'";
 
 impl Config {
     pub fn new(args: &[String]) -> Result<Config, String> {
+        if args.get(1).map(|s| s.as_str()) == Some("import") {
+            let command = args[2..].join(" ");
+            if command.trim().is_empty() {
+                return Err(format!(
+                    "`import` needs a curl command, e.g. lazyreq import 'curl https://api.example.com'\n{}",
+                    USAGE
+                ));
+            }
+            return Ok(Config {
+                filename: String::new(),
+                target: String::new(),
+                mode: Mode::Import(command),
+            });
+        }
+
         let mut mode = Mode::Run;
         let mut filename = String::new();
         let mut target = String::new();
@@ -40,10 +57,7 @@ impl Config {
         }
 
         if !filename.ends_with(".lreq") {
-            return Err(format!(
-                "`{}` is not a .lreq file\n{}",
-                filename, USAGE
-            ));
+            return Err(format!("`{}` is not a .lreq file\n{}", filename, USAGE));
         }
 
         if target.is_empty() && !matches!(mode, Mode::List) {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,0 +1,111 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use sha1::Sha1;
+use sha2::{Sha256, Sha512};
+use uuid::Uuid;
+
+pub fn is_function(name: &str) -> bool {
+    matches!(name, "uuid" | "fuzz_str" | "fuzz_int" | "hmac")
+}
+
+pub fn call(name: &str, args: &[String]) -> Result<String, String> {
+    match name {
+        "uuid" => uuid(args),
+        "fuzz_str" => fuzz_str(args),
+        "fuzz_int" => fuzz_int(args),
+        "hmac" => hmac(args),
+        _ => Err(format!("unknown function `${}()`", name)),
+    }
+}
+
+fn uuid(args: &[String]) -> Result<String, String> {
+    if !args.is_empty() {
+        return Err(format!("$uuid() takes no arguments, got {}", args.len()));
+    }
+    Ok(Uuid::new_v4().to_string())
+}
+
+fn fuzz_str(args: &[String]) -> Result<String, String> {
+    if args.len() != 1 {
+        return Err(format!(
+            "$fuzz_str(len) expects 1 argument, got {}",
+            args.len()
+        ));
+    }
+    let len: usize = args[0]
+        .parse()
+        .map_err(|_| format!("$fuzz_str(len): `{}` is not a valid length", args[0]))?;
+
+    Ok(rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect())
+}
+
+fn fuzz_int(args: &[String]) -> Result<String, String> {
+    if args.len() != 2 {
+        return Err(format!(
+            "$fuzz_int(min, max) expects 2 arguments, got {}",
+            args.len()
+        ));
+    }
+    let min: i64 = args[0]
+        .parse()
+        .map_err(|_| format!("$fuzz_int(min, max): `{}` is not a valid integer", args[0]))?;
+    let max: i64 = args[1]
+        .parse()
+        .map_err(|_| format!("$fuzz_int(min, max): `{}` is not a valid integer", args[1]))?;
+    if min > max {
+        return Err(format!(
+            "$fuzz_int(min, max): min ({}) is greater than max ({})",
+            min, max
+        ));
+    }
+
+    Ok(rand::thread_rng().gen_range(min..=max).to_string())
+}
+
+fn hmac(args: &[String]) -> Result<String, String> {
+    if args.len() < 2 || args.len() > 4 {
+        return Err(format!(
+            "$hmac(data, key, algo?, encoding?) expects 2 to 4 arguments, got {}",
+            args.len()
+        ));
+    }
+    let data = args[0].as_bytes();
+    let key = args[1].as_bytes();
+    let algo = args.get(2).map(|s| s.as_str()).unwrap_or("sha256");
+    let encoding = args.get(3).map(|s| s.as_str()).unwrap_or("base64");
+
+    let digest: Vec<u8> = match algo {
+        "sha1" => sign::<Hmac<Sha1>>(key, data)?,
+        "sha256" => sign::<Hmac<Sha256>>(key, data)?,
+        "sha512" => sign::<Hmac<Sha512>>(key, data)?,
+        other => {
+            return Err(format!(
+                "$hmac(): unknown algorithm `{}` (expected sha1, sha256 or sha512)",
+                other
+            ))
+        }
+    };
+
+    match encoding {
+        "base64" => Ok(BASE64.encode(&digest)),
+        "hex" => Ok(hex::encode(&digest)),
+        other => Err(format!(
+            "$hmac(): unknown encoding `{}` (expected base64 or hex)",
+            other
+        )),
+    }
+}
+
+fn sign<M: Mac + hmac::digest::KeyInit>(key: &[u8], data: &[u8]) -> Result<Vec<u8>, String> {
+    let mut mac = <M as Mac>::new_from_slice(key)
+        .map_err(|_| "$hmac(): invalid key".to_string())?;
+    mac.update(data);
+    Ok(mac.finalize().into_bytes().to_vec())
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -109,3 +109,74 @@ fn sign<M: Mac + hmac::digest::KeyInit>(key: &[u8], data: &[u8]) -> Result<Vec<u
     mac.update(data);
     Ok(mac.finalize().into_bytes().to_vec())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn uuid_is_v4_shaped_and_unique() {
+        let a = call("uuid", &[]).unwrap();
+        let b = call("uuid", &[]).unwrap();
+        assert_eq!(a.len(), 36);
+        assert_eq!(a.as_bytes()[14], b'4');
+        assert_ne!(a, b);
+        assert!(call("uuid", &args(&["nope"])).is_err());
+    }
+
+    #[test]
+    fn fuzz_str_respects_length() {
+        let s = call("fuzz_str", &args(&["12"])).unwrap();
+        assert_eq!(s.len(), 12);
+        assert!(s.chars().all(|c| c.is_ascii_alphanumeric()));
+        assert!(call("fuzz_str", &args(&["banana"])).is_err());
+    }
+
+    #[test]
+    fn fuzz_int_stays_in_range() {
+        for _ in 0..50 {
+            let n: i64 = call("fuzz_int", &args(&["18", "90"])).unwrap().parse().unwrap();
+            assert!((18..=90).contains(&n));
+        }
+        assert!(call("fuzz_int", &args(&["9", "3"])).is_err());
+    }
+
+    #[test]
+    fn hmac_matches_rfc_test_vector() {
+        // RFC 4231-style vector: HMAC-SHA256("key", "The quick brown fox jumps over the lazy dog")
+        let digest = call(
+            "hmac",
+            &args(&[
+                "The quick brown fox jumps over the lazy dog",
+                "key",
+                "sha256",
+                "hex",
+            ]),
+        )
+        .unwrap();
+        assert_eq!(
+            digest,
+            "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
+        );
+    }
+
+    #[test]
+    fn hmac_defaults_to_sha256_base64() {
+        let explicit = call("hmac", &args(&["data", "key", "sha256", "base64"])).unwrap();
+        assert_eq!(call("hmac", &args(&["data", "key"])).unwrap(), explicit);
+        assert!(call("hmac", &args(&["data", "key", "md5"])).is_err());
+        assert!(call("hmac", &args(&["data", "key", "sha256", "morse"])).is_err());
+        assert!(call("hmac", &args(&["data"])).is_err());
+    }
+
+    #[test]
+    fn function_registry() {
+        assert!(is_function("uuid") && is_function("hmac"));
+        assert!(!is_function("body"));
+        assert!(call("nope", &[]).is_err());
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -19,6 +19,11 @@ const KEEP_PER_ID: usize = 20;
 #[derive(Serialize, Deserialize)]
 pub struct Record {
     pub v: u8,
+    /// Unique id of this run (8 hex chars), addressable via --req / --retry.
+    /// Distinct from `id`, the request's name in the .lreq file. Empty on
+    /// records written before this field existed.
+    #[serde(default)]
+    pub req: String,
     pub ts: u64,
     pub id: String,
     pub method: String,
@@ -32,6 +37,16 @@ pub struct Record {
     pub resp_body: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+pub fn new_run_id() -> String {
+    format!("{:08x}", rand::random::<u32>())
+}
+
+/// Looks a single run up by its run id.
+pub fn find(filename: &str, req: &str) -> Result<Option<Record>, String> {
+    let path = history_path(filename)?;
+    Ok(load(&path).into_iter().find(|r| r.req == req))
 }
 
 fn history_path(filename: &str) -> Result<PathBuf, String> {
@@ -97,13 +112,14 @@ fn prune(records: Vec<Record>) -> Vec<Record> {
     kept
 }
 
-fn matches(r: &Record, id: Option<&str>, filter: &HistoryFilter) -> bool {
+fn matches(r: &Record, id: Option<&str>, opts: &HistoryOpts) -> bool {
     id.map_or(true, |id| r.id == id)
-        && match filter {
+        && opts.req.as_deref().map_or(true, |req| r.req == req)
+        && match opts.filter {
             HistoryFilter::All => true,
             HistoryFilter::Success => (200..300).contains(&r.status),
             HistoryFilter::Failed => !(200..300).contains(&r.status),
-            HistoryFilter::Status(code) => r.status == *code,
+            HistoryFilter::Status(code) => r.status == code,
         }
 }
 
@@ -112,7 +128,7 @@ pub fn show(filename: &str, id: Option<&str>, opts: &HistoryOpts) -> Result<(), 
 
     let matches: Vec<&Record> = records
         .iter()
-        .filter(|r| matches(r, id, &opts.filter))
+        .filter(|r| matches(r, id, opts))
         .collect();
 
     if matches.is_empty() {
@@ -158,8 +174,10 @@ fn print_line(r: &Record, id_width: usize) {
         .normal(),
     };
 
+    let req = if r.req.is_empty() { "--------" } else { &r.req };
     println!(
-        "{}  {:id_width$}  {:7} {}  {:>4}ms  {}",
+        "{}  {}  {:id_width$}  {:7} {}  {:>4}ms  {}",
+        req.cyan(),
         format_timestamp(r.ts).dimmed(),
         r.id.bold().green(),
         r.method,
@@ -255,9 +273,20 @@ fn human_size(bytes: usize) -> String {
 mod tests {
     use super::*;
 
+    fn opts(filter: HistoryFilter, req: Option<&str>) -> HistoryOpts {
+        HistoryOpts {
+            last: None,
+            verbose: false,
+            show_headers: false,
+            filter,
+            req: req.map(|s| s.to_string()),
+        }
+    }
+
     fn record(id: &str, ts: u64, status: u16) -> Record {
         Record {
             v: 1,
+            req: new_run_id(),
             ts,
             id: id.to_string(),
             method: "GET".to_string(),
@@ -301,24 +330,52 @@ mod tests {
         let broken = record("login", 3, 500);
         let dead = record("login", 4, 0); // transport error
 
-        assert!(matches(&ok, None, &HistoryFilter::Success));
-        assert!(!matches(&redirect, None, &HistoryFilter::Success));
-        assert!(matches(&broken, None, &HistoryFilter::Failed));
-        assert!(matches(&dead, None, &HistoryFilter::Failed));
-        assert!(matches(&broken, None, &HistoryFilter::Status(500)));
-        assert!(!matches(&broken, None, &HistoryFilter::Status(501)));
-        assert!(matches(&ok, Some("login"), &HistoryFilter::All));
-        assert!(!matches(&ok, Some("me"), &HistoryFilter::All));
+        assert!(matches(&ok, None, &opts(HistoryFilter::Success, None)));
+        assert!(!matches(&redirect, None, &opts(HistoryFilter::Success, None)));
+        assert!(matches(&broken, None, &opts(HistoryFilter::Failed, None)));
+        assert!(matches(&dead, None, &opts(HistoryFilter::Failed, None)));
+        assert!(matches(&broken, None, &opts(HistoryFilter::Status(500), None)));
+        assert!(!matches(&broken, None, &opts(HistoryFilter::Status(501), None)));
+        assert!(matches(&ok, Some("login"), &opts(HistoryFilter::All, None)));
+        assert!(!matches(&ok, Some("me"), &opts(HistoryFilter::All, None)));
+    }
+
+    #[test]
+    fn req_filter_addresses_a_single_run() {
+        let run = record("login", 1, 200);
+        let other = record("login", 2, 200);
+
+        assert!(matches(&run, None, &opts(HistoryFilter::All, Some(&run.req.clone()))));
+        assert!(!matches(&other, None, &opts(HistoryFilter::All, Some(&run.req.clone()))));
+    }
+
+    #[test]
+    fn run_ids_are_unique_and_short() {
+        let a = new_run_id();
+        let b = new_run_id();
+        assert_eq!(a.len(), 8);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b);
     }
 
     #[test]
     fn records_survive_a_jsonl_roundtrip() {
-        let line = serde_json::to_string(&record("login", 42, 200)).unwrap();
+        let rec = record("login", 42, 200);
+        let run_id = rec.req.clone();
+        let line = serde_json::to_string(&rec).unwrap();
         let back: Record = serde_json::from_str(&line).unwrap();
         assert_eq!(back.id, "login");
+        assert_eq!(back.req, run_id);
         assert_eq!(back.ts, 42);
         assert!(back.error.is_none());
         assert!(!line.contains("error")); // None is omitted, not serialized
+    }
+
+    #[test]
+    fn records_from_before_run_ids_still_load() {
+        let legacy = r#"{"v":1,"ts":9,"id":"login","method":"GET","url":"http://x","status":200,"ms":1,"req_headers":{},"req_body":"","resp_body":""}"#;
+        let back: Record = serde_json::from_str(legacy).unwrap();
+        assert_eq!(back.req, "");
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -326,7 +326,7 @@ mod tests {
         let body = r#"{"token": "abcdefgh", "user": {"id": 7, "roles": ["admin", "dev"]}, "ok": true, "score": 1.5, "gone": null}"#;
         assert_eq!(
             shape_of(body),
-            "{gone: null, ok: bool, score: float, token: str(8), user: {id: int, roles: [2 × str(5)]}}"
+            "{token: str(8), user: {id: int, roles: [2 × str(5)]}, ok: bool, score: float, gone: null}"
         );
         assert_eq!(shape_of("[]"), "[]");
         assert_eq!(shape_of("not json at all"), "text(15)");

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,343 @@
+//! Encrypted per-file run history under `~/.lazyreq/history/<hash>.jsonl`.
+//! Every executed request (including hook-triggered runs) appends a record;
+//! the last `KEEP_PER_ID` runs are kept per request id. Reading always goes
+//! through the CLI (`--history`), which renders compact, token-friendly
+//! summaries by default.
+
+use crate::config::{HistoryFilter, HistoryOpts};
+use crate::timest::format_timestamp;
+use crate::vault;
+use colored::*;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+const KEEP_PER_ID: usize = 20;
+
+#[derive(Serialize, Deserialize)]
+pub struct Record {
+    pub v: u8,
+    pub ts: u64,
+    pub id: String,
+    pub method: String,
+    pub url: String,
+    /// HTTP status code; 0 means the request never got a response
+    /// (DNS failure, timeout, connection refused, ...) — see `error`.
+    pub status: u16,
+    pub ms: u64,
+    pub req_headers: HashMap<String, String>,
+    pub req_body: String,
+    pub resp_body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn history_path(filename: &str) -> Result<PathBuf, String> {
+    let dir = vault::lazyreq_dir()?.join("history");
+
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("cannot create history directory `{}`: {}", dir.display(), e))?;
+
+    Ok(dir.join(format!("{}.jsonl", vault::file_id(filename, ""))))
+}
+
+fn load(path: &PathBuf) -> Vec<Record> {
+    // Missing, corrupt or foreign-key files just mean "no history".
+    fs::read(path)
+        .ok()
+        .and_then(|bytes| vault::open(&bytes))
+        .and_then(|plain| String::from_utf8(plain).ok())
+        .map(|text| {
+            text.lines()
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Appends a run, pruning to the newest `KEEP_PER_ID` per request id.
+/// Best-effort by design: recording must never fail the request itself.
+pub fn record(filename: &str, record: Record) {
+    let result = (|| -> Result<(), String> {
+        let path = history_path(filename)?;
+        let mut records = load(&path);
+        records.push(record);
+        let kept = prune(records);
+
+        let lines: Vec<String> = kept
+            .iter()
+            .filter_map(|r| serde_json::to_string(r).ok())
+            .collect();
+        let sealed = vault::seal(lines.join("\n").as_bytes())?;
+        fs::write(&path, sealed).map_err(|e| format!("cannot write `{}`: {}", path.display(), e))
+    })();
+
+    if let Err(e) = result {
+        eprintln!("{} could not record history: {}", "warning:".yellow(), e);
+    }
+}
+
+/// Keeps the newest `KEEP_PER_ID` records per request id, preserving order.
+fn prune(records: Vec<Record>) -> Vec<Record> {
+    let mut per_id: HashMap<String, usize> = HashMap::new();
+    for r in &records {
+        *per_id.entry(r.id.clone()).or_insert(0) += 1;
+    }
+
+    let mut kept = Vec::with_capacity(records.len());
+    for r in records.into_iter() {
+        let remaining = per_id.get_mut(&r.id).unwrap();
+        if *remaining <= KEEP_PER_ID {
+            kept.push(r);
+        }
+        *remaining -= 1;
+    }
+    kept
+}
+
+fn matches(r: &Record, id: Option<&str>, filter: &HistoryFilter) -> bool {
+    id.map_or(true, |id| r.id == id)
+        && match filter {
+            HistoryFilter::All => true,
+            HistoryFilter::Success => (200..300).contains(&r.status),
+            HistoryFilter::Failed => !(200..300).contains(&r.status),
+            HistoryFilter::Status(code) => r.status == *code,
+        }
+}
+
+pub fn show(filename: &str, id: Option<&str>, opts: &HistoryOpts) -> Result<(), String> {
+    let records = load(&history_path(filename)?);
+
+    let matches: Vec<&Record> = records
+        .iter()
+        .filter(|r| matches(r, id, &opts.filter))
+        .collect();
+
+    if matches.is_empty() {
+        println!(
+            "no matching history for {}{} yet",
+            filename,
+            id.map(|id| format!(" `{}`", id)).unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    let limit = opts.last.unwrap_or(usize::MAX);
+    let shown = &matches[matches.len().saturating_sub(limit)..];
+    let id_width = shown.iter().map(|r| r.id.len()).max().unwrap_or(0);
+
+    for record in shown {
+        print_line(record, id_width);
+        if opts.verbose {
+            print_details(record, opts.show_headers);
+        } else if id.is_some() {
+            println!("    {}", shape_of(&record.resp_body).dimmed());
+        }
+    }
+
+    Ok(())
+}
+
+fn print_line(r: &Record, id_width: usize) {
+    let status = match r.status {
+        0 => "ERR".bold().red(),
+        200..=299 => r.status.to_string().bold().green(),
+        300..=399 => r.status.to_string().bold().yellow(),
+        _ => r.status.to_string().bold().red(),
+    };
+
+    let tail = match &r.error {
+        Some(e) => e.normal(),
+        None => format!(
+            "body:{}  headers:{}",
+            human_size(r.resp_body.len()),
+            r.req_headers.len()
+        )
+        .normal(),
+    };
+
+    println!(
+        "{}  {:id_width$}  {:7} {}  {:>4}ms  {}",
+        format_timestamp(r.ts).dimmed(),
+        r.id.bold().green(),
+        r.method,
+        status,
+        r.ms,
+        tail,
+    );
+}
+
+fn print_details(r: &Record, show_headers: bool) {
+    println!("    {} {}", "url:".bold(), r.url);
+
+    if show_headers {
+        for (name, value) in &r.req_headers {
+            println!("    {} {} = {}", "H:".bold(), name, value);
+        }
+    }
+
+    if !r.req_body.is_empty() {
+        println!("    {}", "request:".bold());
+        println!("{}", indent(&pretty(&r.req_body), 6));
+    }
+
+    if let Some(e) = &r.error {
+        println!("    {} {}", "error:".bold().red(), e);
+    }
+
+    if !r.resp_body.is_empty() {
+        println!("    {}", "response:".bold());
+        println!("{}", indent(&pretty(&r.resp_body), 6));
+    }
+    println!();
+}
+
+fn pretty(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| body.to_string())
+}
+
+fn indent(text: &str, spaces: usize) -> String {
+    text.lines()
+        .map(|l| format!("{:spaces$}{}", "", l))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Token-frugal structural summary of a response body: keys and types
+/// instead of values, e.g. `{token: str(212), user: {id: str, roles: [2 × str]}}`.
+fn shape_of(body: &str) -> String {
+    if body.is_empty() {
+        return "(empty body)".to_string();
+    }
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => shape(&value, 0),
+        Err(_) => format!("text({})", body.len()),
+    }
+}
+
+fn shape(value: &Value, depth: usize) -> String {
+    if depth > 4 {
+        return "…".to_string();
+    }
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(_) => "bool".to_string(),
+        Value::Number(n) => if n.is_f64() { "float" } else { "int" }.to_string(),
+        Value::String(s) => format!("str({})", s.chars().count()),
+        Value::Array(items) => match items.first() {
+            None => "[]".to_string(),
+            Some(first) => format!("[{} × {}]", items.len(), shape(first, depth + 1)),
+        },
+        Value::Object(map) => {
+            let fields: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, shape(v, depth + 1)))
+                .collect();
+            format!("{{{}}}", fields.join(", "))
+        }
+    }
+}
+
+fn human_size(bytes: usize) -> String {
+    match bytes {
+        0..=1023 => format!("{}b", bytes),
+        1024..=1_048_575 => format!("{:.1}kb", bytes as f64 / 1024.0),
+        _ => format!("{:.1}mb", bytes as f64 / 1_048_576.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: &str, ts: u64, status: u16) -> Record {
+        Record {
+            v: 1,
+            ts,
+            id: id.to_string(),
+            method: "GET".to_string(),
+            url: "http://localhost/x".to_string(),
+            status,
+            ms: 1,
+            req_headers: HashMap::new(),
+            req_body: String::new(),
+            resp_body: String::new(),
+            error: if status == 0 {
+                Some("connection refused".to_string())
+            } else {
+                None
+            },
+        }
+    }
+
+    #[test]
+    fn prune_keeps_newest_per_id_without_starving_rare_ids() {
+        let mut records: Vec<Record> = (0..30).map(|i| record("login", i, 200)).collect();
+        records.insert(0, record("me", 1000, 200)); // old, rarely-run request
+
+        let kept = prune(records);
+
+        assert_eq!(kept.len(), KEEP_PER_ID + 1);
+        assert!(kept.iter().any(|r| r.id == "me")); // hot id can't evict it
+        let login_ts: Vec<u64> = kept.iter().filter(|r| r.id == "login").map(|r| r.ts).collect();
+        assert_eq!(login_ts, (10..30).collect::<Vec<u64>>()); // newest 20, in order
+    }
+
+    #[test]
+    fn prune_leaves_small_histories_alone() {
+        let kept = prune(vec![record("a", 1, 200), record("b", 2, 500)]);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn filters_match_status_classes() {
+        let ok = record("login", 1, 200);
+        let redirect = record("login", 2, 302);
+        let broken = record("login", 3, 500);
+        let dead = record("login", 4, 0); // transport error
+
+        assert!(matches(&ok, None, &HistoryFilter::Success));
+        assert!(!matches(&redirect, None, &HistoryFilter::Success));
+        assert!(matches(&broken, None, &HistoryFilter::Failed));
+        assert!(matches(&dead, None, &HistoryFilter::Failed));
+        assert!(matches(&broken, None, &HistoryFilter::Status(500)));
+        assert!(!matches(&broken, None, &HistoryFilter::Status(501)));
+        assert!(matches(&ok, Some("login"), &HistoryFilter::All));
+        assert!(!matches(&ok, Some("me"), &HistoryFilter::All));
+    }
+
+    #[test]
+    fn records_survive_a_jsonl_roundtrip() {
+        let line = serde_json::to_string(&record("login", 42, 200)).unwrap();
+        let back: Record = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.id, "login");
+        assert_eq!(back.ts, 42);
+        assert!(back.error.is_none());
+        assert!(!line.contains("error")); // None is omitted, not serialized
+    }
+
+    #[test]
+    fn shape_summarizes_structure_not_values() {
+        let body = r#"{"token": "abcdefgh", "user": {"id": 7, "roles": ["admin", "dev"]}, "ok": true, "score": 1.5, "gone": null}"#;
+        assert_eq!(
+            shape_of(body),
+            "{gone: null, ok: bool, score: float, token: str(8), user: {id: int, roles: [2 × str(5)]}}"
+        );
+        assert_eq!(shape_of("[]"), "[]");
+        assert_eq!(shape_of("not json at all"), "text(15)");
+        assert_eq!(shape_of(""), "(empty body)");
+    }
+
+    #[test]
+    fn human_sizes() {
+        assert_eq!(human_size(0), "0b");
+        assert_eq!(human_size(1023), "1023b");
+        assert_eq!(human_size(1536), "1.5kb");
+        assert_eq!(human_size(3 * 1024 * 1024), "3.0mb");
+    }
+}

--- a/src/import.rs
+++ b/src/import.rs
@@ -129,11 +129,22 @@ pub fn curl_to_lreq(command: &str) -> Result<String, String> {
         out.push_str(&format!("M: {} = {}\n", name, escape(value)));
     }
     if !body_parts.is_empty() {
-        out.push_str(&body_parts.join("&"));
+        out.push_str(&prettify_body(&body_parts.join("&")));
         out.push('\n');
     }
 
     Ok(out)
+}
+
+/// JSON bodies come out of "Copy as cURL" compacted onto one line; reformat
+/// them so the .lreq block is readable. Anything that isn't JSON (form
+/// payloads, plain text) is left untouched.
+fn prettify_body(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .filter(|v| v.is_object() || v.is_array())
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| body.to_string())
 }
 
 /// `$` is special in .lreq strict contexts (URLs, headers, multipart), so
@@ -189,6 +200,19 @@ fn shell_split(input: &str) -> Result<Vec<String>, String> {
                 // A backslash at end of line is a line continuation.
                 match chars.next() {
                     Some('\n') | None => {}
+                    Some('\r') => {
+                        // Windows line continuation: \ + CRLF.
+                        if chars.peek() == Some(&'\n') {
+                            chars.next();
+                        }
+                    }
+                    Some(' ' | '\t') if !has_word => {
+                        // A continuation backslash with trailing whitespace,
+                        // or one whose newline was eaten by a single-line
+                        // paste (e.g. an editor input box): a standalone
+                        // whitespace-only word is never meaningful in a curl
+                        // command, so drop it instead of failing.
+                    }
                     Some(next) => {
                         current.push(next);
                         has_word = true;
@@ -255,4 +279,59 @@ fn shell_split(input: &str) -> Result<Vec<String>, String> {
     }
 
     Ok(words)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn imports_a_multiline_curl_with_continuations() {
+        let block = curl_to_lreq(
+            "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  https://api.x.dev/users",
+        )
+        .unwrap();
+        assert!(block.contains("ID: users"));
+        assert!(block.contains("POST https://api.x.dev/users"));
+        assert!(block.contains("H: Content-Type = application/json"));
+    }
+
+    #[test]
+    fn tolerates_continuations_flattened_by_a_single_line_paste() {
+        // Pasting a multiline command into a single-line input eats the
+        // newlines, leaving `\ ` between words.
+        let block = curl_to_lreq("curl -X POST \\ https://foo.com").unwrap();
+        assert!(block.contains("POST https://foo.com"));
+
+        // Trailing whitespace after the continuation backslash.
+        let block = curl_to_lreq("curl -X POST \\ \nhttps://foo.com").unwrap();
+        assert!(block.contains("POST https://foo.com"));
+
+        // Windows CRLF continuations.
+        let block = curl_to_lreq("curl -X POST \\\r\nhttps://foo.com").unwrap();
+        assert!(block.contains("POST https://foo.com"));
+    }
+
+    #[test]
+    fn escaped_spaces_inside_words_still_work() {
+        let block = curl_to_lreq("curl https://x.dev -F file=@my\\ photo.png").unwrap();
+        assert!(block.contains("M: file = file://my photo.png"));
+    }
+
+    #[test]
+    fn json_bodies_are_pretty_printed() {
+        let block =
+            curl_to_lreq(r#"curl https://x.dev/orders -d '{"shop_id": 13733,"id": 12312}'"#)
+                .unwrap();
+        assert!(block.ends_with("{\n  \"shop_id\": 13733,\n  \"id\": 12312\n}\n"));
+    }
+
+    #[test]
+    fn non_json_bodies_are_left_alone() {
+        let block = curl_to_lreq("curl https://x.dev -d a=1 -d b=2").unwrap();
+        assert!(block.ends_with("a=1&b=2\n"));
+
+        let block = curl_to_lreq(r#"curl https://x.dev -d '"just a string"'"#).unwrap();
+        assert!(block.ends_with("\"just a string\"\n"));
+    }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,0 +1,258 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
+/// Converts a curl command (e.g. from a browser's "Copy as cURL") into a
+/// .lreq request block.
+pub fn curl_to_lreq(command: &str) -> Result<String, String> {
+    let words = shell_split(command)?;
+    if words.is_empty() || words[0] != "curl" {
+        return Err("expected a command starting with `curl`".to_string());
+    }
+
+    let mut method: Option<String> = None;
+    let mut url: Option<String> = None;
+    let mut headers: Vec<(String, String)> = Vec::new();
+    let mut body_parts: Vec<String> = Vec::new();
+    let mut multipart: Vec<(String, String)> = Vec::new();
+
+    let mut iter = words.iter().skip(1);
+    while let Some(word) = iter.next() {
+        let mut value = |flag: &str| -> Result<String, String> {
+            iter.next()
+                .cloned()
+                .ok_or(format!("`{}` is missing its value", flag))
+        };
+
+        match word.as_str() {
+            "-X" | "--request" => method = Some(value(word)?.to_uppercase()),
+            "-H" | "--header" => {
+                let header = value(word)?;
+                match header.split_once(':') {
+                    Some((name, val)) => {
+                        headers.push((name.trim().to_string(), val.trim().to_string()));
+                    }
+                    None => return Err(format!("invalid header `{}`", header)),
+                }
+            }
+            "-d" | "--data" | "--data-raw" | "--data-binary" | "--data-ascii"
+            | "--data-urlencode" => {
+                let mut data = value(word)?;
+                if let Some(stripped) = data.strip_prefix('@') {
+                    return Err(format!(
+                        "`{} @{}` reads a file; paste the body inline instead",
+                        word, stripped
+                    ));
+                }
+                if data.starts_with('$') {
+                    // ANSI-C quoted strings arrive as $'...' when copied from
+                    // some browsers; shell_split already handled quotes, so a
+                    // leading $ here is just data.
+                    data = data.to_string();
+                }
+                body_parts.push(data);
+            }
+            "-F" | "--form" => {
+                let field = value(word)?;
+                match field.split_once('=') {
+                    Some((name, val)) => {
+                        let val = match val.strip_prefix('@') {
+                            Some(path) => format!("file://{}", path),
+                            None => val.to_string(),
+                        };
+                        multipart.push((name.trim().to_string(), val));
+                    }
+                    None => return Err(format!("invalid form field `{}`", field)),
+                }
+            }
+            "-u" | "--user" => {
+                let credentials = value(word)?;
+                headers.push((
+                    "Authorization".to_string(),
+                    format!("Basic {}", BASE64.encode(credentials.as_bytes())),
+                ));
+            }
+            "-b" | "--cookie" => {
+                let cookie = value(word)?;
+                headers.push(("Cookie".to_string(), cookie));
+            }
+            "-A" | "--user-agent" => {
+                let agent = value(word)?;
+                headers.push(("User-Agent".to_string(), agent));
+            }
+            "-e" | "--referer" => {
+                let referer = value(word)?;
+                headers.push(("Referer".to_string(), referer));
+            }
+            "--url" => url = Some(value(word)?),
+            // Flags that take a value we don't map — consume and ignore it.
+            "-o" | "--output" | "--connect-timeout" | "--max-time" | "-m" | "--retry"
+            | "--cacert" | "--capath" | "-c" | "--cookie-jar" | "-w" | "--write-out" => {
+                value(word)?;
+            }
+            // Boolean flags we can safely ignore.
+            "-s" | "--silent" | "-S" | "--show-error" | "-L" | "--location" | "-k"
+            | "--insecure" | "--compressed" | "-i" | "--include" | "-v" | "--verbose"
+            | "-f" | "--fail" | "-g" | "--globoff" => {}
+            "-G" | "--get" => method = Some("GET".to_string()),
+            "-I" | "--head" => method = Some("HEAD".to_string()),
+            other => {
+                if other.starts_with('-') {
+                    return Err(format!(
+                        "unsupported curl flag `{}` — remove it and try again",
+                        other
+                    ));
+                }
+                if url.is_some() {
+                    return Err(format!("unexpected argument `{}`", other));
+                }
+                url = Some(other.to_string());
+            }
+        }
+    }
+
+    let url = url.ok_or("no URL found in the curl command".to_string())?;
+    let method = method.unwrap_or_else(|| {
+        if body_parts.is_empty() && multipart.is_empty() {
+            "GET".to_string()
+        } else {
+            "POST".to_string()
+        }
+    });
+
+    let id = suggest_id(&url);
+    let mut out = format!("ID: {}\n{} {}\n", id, method, escape(&url));
+
+    for (name, value) in &headers {
+        out.push_str(&format!("H: {} = {}\n", name, escape(value)));
+    }
+    for (name, value) in &multipart {
+        out.push_str(&format!("M: {} = {}\n", name, escape(value)));
+    }
+    if !body_parts.is_empty() {
+        out.push_str(&body_parts.join("&"));
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+/// `$` is special in .lreq strict contexts (URLs, headers, multipart), so
+/// literal dollars from the imported command are escaped as `$$`.
+fn escape(value: &str) -> String {
+    value.replace('$', "$$")
+}
+
+fn suggest_id(url: &str) -> String {
+    let no_query = url.split('?').next().unwrap_or(url);
+    // Skip the scheme and host so `https://api.x.com` doesn't become `api-x-com`.
+    let after_scheme = no_query.split("://").nth(1).unwrap_or(no_query);
+    let mut segments = after_scheme.trim_end_matches('/').split('/');
+    segments.next(); // host
+
+    let last = segments.last().unwrap_or("");
+    let cleaned: String = last
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    if cleaned.trim_matches('-').is_empty() {
+        "imported".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Splits a shell command into words, honoring single quotes, double quotes,
+/// backslash escapes and ANSI-C `$'...'` quoting — enough for pasted curl
+/// commands from browsers and docs.
+fn shell_split(input: &str) -> Result<Vec<String>, String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut has_word = false;
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            ' ' | '\t' | '\n' | '\r' => {
+                if has_word {
+                    words.push(std::mem::take(&mut current));
+                    has_word = false;
+                }
+            }
+            '\\' => {
+                // A backslash at end of line is a line continuation.
+                match chars.next() {
+                    Some('\n') | None => {}
+                    Some(next) => {
+                        current.push(next);
+                        has_word = true;
+                    }
+                }
+            }
+            '\'' => {
+                has_word = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some(inner) => current.push(inner),
+                        None => return Err("unclosed single quote".to_string()),
+                    }
+                }
+            }
+            '"' => {
+                has_word = true;
+                loop {
+                    match chars.next() {
+                        Some('"') => break,
+                        Some('\\') => match chars.next() {
+                            Some(escaped @ ('"' | '\\' | '$' | '`')) => current.push(escaped),
+                            Some(other) => {
+                                current.push('\\');
+                                current.push(other);
+                            }
+                            None => return Err("unclosed double quote".to_string()),
+                        },
+                        Some(inner) => current.push(inner),
+                        None => return Err("unclosed double quote".to_string()),
+                    }
+                }
+            }
+            '$' if chars.peek() == Some(&'\'') => {
+                // ANSI-C quoting: $'...' — treat like single quotes with
+                // basic escape handling.
+                chars.next();
+                has_word = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some('\\') => match chars.next() {
+                            Some('n') => current.push('\n'),
+                            Some('t') => current.push('\t'),
+                            Some('r') => current.push('\r'),
+                            Some(escaped) => current.push(escaped),
+                            None => return Err("unclosed $' quote".to_string()),
+                        },
+                        Some(inner) => current.push(inner),
+                        None => return Err("unclosed $' quote".to_string()),
+                    }
+                }
+            }
+            _ => {
+                current.push(c);
+                has_word = true;
+            }
+        }
+    }
+
+    if has_word {
+        words.push(current);
+    }
+
+    Ok(words)
+}

--- a/src/lazyreq.rs
+++ b/src/lazyreq.rs
@@ -1,6 +1,5 @@
 use async_recursion::async_recursion;
 use colored::*;
-use core::panic;
 use mime_guess::from_path;
 use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -14,13 +13,26 @@ use std::path::Path;
 use std::{env, fs};
 
 use crate::cache::Cache;
+use crate::functions;
 use crate::request::Request;
+
+const MAX_DEPTH: usize = 16;
+const TOKEN_PATTERN: &str = r"\$\$|\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*(?:\([^)]*\))?";
 
 pub struct LazyReq {
     variables: HashMap<String, String>,
     hooks: HashMap<String, String>,
     requests: HashMap<String, Request>,
+    order: Vec<String>,
     filename: String,
+}
+
+/// A resolved request, ready to send: everything interpolated.
+struct Prepared {
+    url: String,
+    headers: HashMap<String, String>,
+    body: String,
+    multipart: Vec<(String, String)>,
 }
 
 impl LazyReq {
@@ -29,392 +41,631 @@ impl LazyReq {
             variables: HashMap::new(),
             hooks: HashMap::new(),
             requests: HashMap::new(),
+            order: Vec::new(),
             filename: "".to_string(),
         }
     }
 
-    pub async fn do_request(&self, id: String) {
-        match self.requests.get(&id) {
-            Some(req) => {
-                print!(
-                    "{}{}{}",
-                    "[".bold().green(),
-                    req.method.clone().bold().green(),
-                    "]".bold().green()
-                );
-                let (status, url, result) = self.execute(req).await.unwrap();
-                print!(" {}\n", url.bold().green());
+    pub fn list(&self) {
+        let width = self
+            .order
+            .iter()
+            .map(|id| id.len())
+            .max()
+            .unwrap_or(0);
 
-                println!("{} {}", "Status:".bold().green(), status.bold().green());
-                let pretty_json: Value =
-                    serde_json::from_str(&result.as_str()).unwrap_or(Value::Null);
-                if !pretty_json.is_null() {
-                    println!("{}", to_string_pretty(&pretty_json).unwrap());
-                } else {
-                    println!("{}", result.bold().green());
-                }
-            }
-            None => {
-                println!("Request not found");
-            }
+        for id in &self.order {
+            let req = &self.requests[id];
+            println!(
+                "{:width$}  {:7} {}",
+                id.bold().green(),
+                req.method,
+                req.path,
+                width = width
+            );
         }
     }
 
-    pub async fn export_curl(&self, id: String) {
-        match self.requests.get(&id) {
-            Some(req) => {
-                let curl_command = self.generate_curl_command(req).await;
-                println!("{}", curl_command);
-            }
-            None => {
-                println!("Request not found");
-            }
+    pub async fn do_request(&self, id: String) -> Result<(), String> {
+        let req = self.requests.get(&id).ok_or(format!(
+            "request `{}` not found in {} (use --list to see available requests)",
+            id, self.filename
+        ))?;
+
+        let (status, url, result) = self
+            .execute(req, 0)
+            .await
+            .map_err(|e| format!("request `{}` failed:\n  {}", id, e))?;
+
+        let status_colored = match status.chars().next() {
+            Some('2') => status.bold().green(),
+            Some('3') => status.bold().yellow(),
+            _ => status.bold().red(),
+        };
+
+        println!(
+            "{}{}{} {}",
+            "[".bold().green(),
+            req.method.bold().green(),
+            "]".bold().green(),
+            url.bold().green()
+        );
+        println!("{} {}", "Status:".bold().green(), status_colored);
+
+        let pretty_json: Value = serde_json::from_str(result.as_str()).unwrap_or(Value::Null);
+        if !pretty_json.is_null() {
+            println!("{}", to_string_pretty(&pretty_json).unwrap());
+        } else {
+            println!("{}", result);
         }
+
+        Ok(())
     }
 
-    async fn generate_curl_command(&self, req: &Request) -> String {
-        let url = self.handle_variables_and_hooks(req.path.clone()).await;
-        
-        let mut headers = req.headers.clone();
-        for (key, value) in &req.headers {
-            let normalized = self.handle_variables_and_hooks(value.clone()).await;
-            headers.insert(key.clone(), normalized.clone());
-        }
+    pub async fn export_curl(&self, id: String) -> Result<(), String> {
+        let req = self.requests.get(&id).ok_or(format!(
+            "request `{}` not found in {} (use --list to see available requests)",
+            id, self.filename
+        ))?;
+
+        let prepared = self
+            .prepare(req, 0)
+            .await
+            .map_err(|e| format!("cannot resolve request `{}`:\n  {}", id, e))?;
 
         let mut curl_parts = vec![format!("curl -X {}", req.method.to_uppercase())];
-        
-        // Add headers
-        for (key, value) in &headers {
+
+        for (key, value) in &prepared.headers {
             curl_parts.push(format!("-H \"{}: {}\"", key, value));
         }
 
-        // Handle multipart data
-        if !req.multipart.is_empty() {
-            for part in &req.multipart {
-                if part.content.starts_with("file://") {
-                    let path_str = part.content.clone().replace("file://", "");
-                    curl_parts.push(format!("-F \"{}=@{}\"", part.name, path_str));
-                } else if part.content.starts_with("download://") {
-                    // For download URLs, we can't easily convert to curl without downloading first
-                    // So we'll just include the URL as a form field
-                    curl_parts.push(format!("-F \"{}={}\"", part.name, part.content));
+        if !prepared.multipart.is_empty() {
+            for (name, content) in &prepared.multipart {
+                if let Some(path) = content.strip_prefix("file://") {
+                    curl_parts.push(format!("-F \"{}=@{}\"", name, path));
                 } else {
-                    curl_parts.push(format!("-F \"{}={}\"", part.name, part.content));
+                    curl_parts.push(format!("-F \"{}={}\"", name, content));
                 }
             }
-        } else if !req.body.is_empty() {
-            // Add body data
-            curl_parts.push(format!("-d '{}'", req.body));
+        } else if !prepared.body.is_empty() {
+            curl_parts.push(format!("-d '{}'", prepared.body));
         }
 
-        // Add URL
-        curl_parts.push(format!("\"{}\"", url));
+        curl_parts.push(format!("\"{}\"", prepared.url));
 
-        curl_parts.join(" \\\n  ")
+        println!("{}", curl_parts.join(" \\\n  "));
+        Ok(())
     }
 
+    /// Interpolates `$variables`, `$env.X`, `$hook.field` references, `$body`
+    /// and `$function(...)` calls in `input`.
+    ///
+    /// `strict` mode (URLs, headers, multipart values) errors on unknown
+    /// tokens; lenient mode (request bodies) passes them through untouched so
+    /// natural dollar-words in JSON (`$gte`, `$set`, ...) keep working.
     #[async_recursion]
-    pub async fn handle_macro(&self, macr: String, splits: Vec<&str>) -> (String, String) {
-        if macr.starts_with("$req.") {
-            let macro_parsed = &macr.replace("$req.", "");
-
-            let mut cacher: Option<Cache> = None;
-            if splits.len() > 1 {
-                cacher = Some(Cache::new(&self.filename, macro_parsed));
-                let has = cacher.as_mut().unwrap().get();
-                if has.is_some() {
-                    return (macro_parsed.clone(), has.unwrap());
-                }
-            }
-
-            let req = self.requests.get(macro_parsed).unwrap();
-            let (_, _, result) = self.execute(req).await.unwrap();
-            if splits.len() > 1 && cacher.is_some() {
-                cacher
-                    .as_mut()
-                    .unwrap()
-                    .set(result.clone(), splits[1].parse::<u64>().unwrap());
-            }
-
-            return (macro_parsed.clone(), result);
+    async fn interpolate(
+        &self,
+        input: &str,
+        strict: bool,
+        body: Option<&str>,
+        depth: usize,
+    ) -> Result<String, String> {
+        if depth > MAX_DEPTH {
+            return Err("recursion limit reached (circular hook reference?)".to_string());
         }
 
-        return (String::new(), String::new());
-    }
+        let re = Regex::new(TOKEN_PATTERN).unwrap();
+        let mut output = String::with_capacity(input.len());
+        let mut last_end = 0;
 
-    #[async_recursion]
-    async fn handle_variables_and_hooks(&self, data: String) -> String {
-        let pattern = r"\$[\w.]+";
-        let re = Regex::new(pattern).unwrap();
+        for m in re.find_iter(input) {
+            output.push_str(&input[last_end..m.start()]);
+            last_end = m.end();
 
-        let mut url = data.clone();
-        for i in re.find_iter(&data) {
-            if i.as_str().starts_with("$$") {
+            let token = m.as_str();
+            if token == "$$" {
+                output.push('$');
                 continue;
             }
 
-            let replace_value = i.clone().as_str();
-            let mut item: String = i.as_str().chars().skip(1).collect();
-
-            item = item.split(".").collect::<Vec<&str>>()[0].to_string();
-
-            let is_hook = self.hooks.get(item.as_str().trim());
-            if is_hook.is_some() {
-                let hook = is_hook.unwrap().to_string();
-                let parts: Vec<&str> = hook.split(" ").collect::<Vec<&str>>();
-
-                let (macro_name, macro_result) =
-                    self.handle_macro(parts[0].to_string(), parts).await;
-                let mut parsed: Value = serde_json::from_str(&macro_result.as_str()).unwrap();
-
-                let macro_name_parsed = "$".to_string() + macro_name.as_str() + ".";
-                let replaced = replace_value.replace(macro_name_parsed.as_str(), "");
-                let parts = replaced.split(".").collect::<Vec<&str>>();
-
-                for part in parts.iter() {
-                    if parsed.get(part).is_none() {
-                        panic!("Macro {} not found", replace_value);
-                    }
-
-                    parsed = parsed.get(part).unwrap().clone();
-                }
-
-                url = url.replace(&replace_value, &parsed.as_str().unwrap())
-            }
-
-            let is_variable = self.variables.get(item.as_str());
-            if is_variable.is_some() {
-                url = url.replace(&replace_value, &is_variable.unwrap().to_string());
-            }
-
-            if !is_variable.is_some() && !is_hook.is_some() {
-                panic!(
-                    "Variable or hook not found: {}",
-                    item.to_string().to_string()
-                );
-            }
-
-            // url = url.replace(&item, &self.variables.get(&item).unwrap());
+            let resolved = self.resolve_token(token, strict, body, depth).await?;
+            output.push_str(&resolved);
         }
 
-        return url;
+        output.push_str(&input[last_end..]);
+        Ok(output)
+    }
+
+    async fn resolve_token(
+        &self,
+        token: &str,
+        strict: bool,
+        body: Option<&str>,
+        depth: usize,
+    ) -> Result<String, String> {
+        // Split "$name.path.to.field(args)" into its pieces.
+        let inner = &token[1..];
+        let (name_path, args) = match inner.find('(') {
+            Some(idx) => (
+                &inner[..idx],
+                Some(inner[idx + 1..inner.len() - 1].to_string()),
+            ),
+            None => (inner, None),
+        };
+        let mut segments = name_path.split('.');
+        let name = segments.next().unwrap();
+        let path: Vec<&str> = segments.collect();
+
+        // Function call: $uuid(), $hmac(data, key), ...
+        if let Some(args_str) = args {
+            if path.is_empty() && functions::is_function(name) {
+                let mut resolved_args = Vec::new();
+                if !args_str.trim().is_empty() {
+                    for raw in args_str.split(',') {
+                        let interpolated =
+                            self.interpolate(raw.trim(), true, body, depth + 1).await?;
+                        resolved_args.push(strip_quotes(&interpolated));
+                    }
+                }
+                return functions::call(name, &resolved_args);
+            }
+
+            if strict {
+                return Err(format!(
+                    "unknown function `${}()` (available: $uuid, $fuzz_str, $fuzz_int, $hmac)",
+                    name_path
+                ));
+            }
+            return Ok(token.to_string());
+        }
+
+        // $env.VAR_NAME
+        if name == "env" {
+            let var = path.join(".");
+            if var.is_empty() {
+                return Err("`$env` needs a variable name, e.g. `$env.API_TOKEN`".to_string());
+            }
+            return env::var(&var)
+                .map_err(|_| format!("environment variable `{}` is not set", var));
+        }
+
+        // $body — the interpolated body of the request being sent
+        if name == "body" && path.is_empty() {
+            match body {
+                Some(b) => return Ok(b.to_string()),
+                None => {
+                    if strict {
+                        return Err(
+                            "`$body` is only available in URLs, headers and multipart values"
+                                .to_string(),
+                        );
+                    }
+                    return Ok(token.to_string());
+                }
+            }
+        }
+
+        // Hook: $login.token — executes the hooked request and drills into
+        // its JSON response.
+        if let Some(hook_def) = self.hooks.get(name) {
+            let response = self.resolve_hook(name, hook_def, depth).await?;
+            if path.is_empty() {
+                return Ok(response);
+            }
+
+            let mut parsed: Value = serde_json::from_str(&response).map_err(|_| {
+                format!(
+                    "hook `{}` response is not JSON, cannot resolve `{}`",
+                    name, token
+                )
+            })?;
+
+            for part in &path {
+                parsed = match parsed.get(part) {
+                    Some(v) => v.clone(),
+                    None => {
+                        let available = match &parsed {
+                            Value::Object(map) => format!(
+                                " (available fields: {})",
+                                map.keys().cloned().collect::<Vec<_>>().join(", ")
+                            ),
+                            _ => String::new(),
+                        };
+                        return Err(format!(
+                            "field `{}` not found in response of hook `{}`{}",
+                            part, name, available
+                        ));
+                    }
+                };
+            }
+
+            return Ok(match parsed {
+                Value::String(s) => s,
+                other => other.to_string(),
+            });
+        }
+
+        // Plain variable
+        if let Some(value) = self.variables.get(name) {
+            let mut result = value.clone();
+            if !path.is_empty() {
+                result.push('.');
+                result.push_str(&path.join("."));
+            }
+            return Ok(result);
+        }
+
+        if strict {
+            return Err(format!(
+                "unknown variable or hook `{}` (use `$${}` for a literal `$`)",
+                token,
+                &token[1..]
+            ));
+        }
+        Ok(token.to_string())
+    }
+
+    async fn resolve_hook(
+        &self,
+        name: &str,
+        definition: &str,
+        depth: usize,
+    ) -> Result<String, String> {
+        let parts: Vec<&str> = definition.split_whitespace().collect();
+        let req_id = parts[0].strip_prefix("$req.").ok_or(format!(
+            "invalid hook `{}`: expected `$req.<request-id> [cache-seconds]`, got `{}`",
+            name, definition
+        ))?;
+
+        let ttl: Option<u64> = match parts.get(1) {
+            Some(raw) => Some(raw.parse().map_err(|_| {
+                format!(
+                    "invalid cache duration `{}` on hook `{}` (expected seconds)",
+                    raw, name
+                )
+            })?),
+            None => None,
+        };
+
+        let mut cacher = match ttl {
+            Some(_) => Some(Cache::new(&self.filename, req_id)?),
+            None => None,
+        };
+        if let Some(c) = cacher.as_mut() {
+            if let Some(cached) = c.get() {
+                return Ok(cached);
+            }
+        }
+
+        let req = self.requests.get(req_id).ok_or(format!(
+            "hook `{}` references unknown request `{}`",
+            name, req_id
+        ))?;
+
+        let (status, _, result) = self
+            .execute(req, depth + 1)
+            .await
+            .map_err(|e| format!("hook `{}` (request `{}`) failed: {}", name, req_id, e))?;
+
+        if !status.starts_with('2') {
+            return Err(format!(
+                "hook `{}` (request `{}`) returned status {}: {}",
+                name, req_id, status, result
+            ));
+        }
+
+        if let (Some(c), Some(seconds)) = (cacher.as_mut(), ttl) {
+            c.set(result.clone(), seconds)?;
+        }
+
+        Ok(result)
+    }
+
+    /// Resolves every dynamic part of a request: body first (lenient), then
+    /// URL, headers and multipart values (strict, with `$body` available).
+    async fn prepare(&self, req: &Request, depth: usize) -> Result<Prepared, String> {
+        if depth > MAX_DEPTH {
+            return Err("recursion limit reached (circular hook reference?)".to_string());
+        }
+
+        let body = if req.body.is_empty() {
+            String::new()
+        } else {
+            self.interpolate(&req.body, false, None, depth).await?
+        };
+
+        let url = self.interpolate(&req.path, true, Some(&body), depth).await?;
+
+        let mut headers = HashMap::new();
+        for (key, value) in &req.headers {
+            let resolved = self.interpolate(value, true, Some(&body), depth).await?;
+            headers.insert(key.clone(), resolved);
+        }
+
+        let mut parts = Vec::new();
+        for part in &req.multipart {
+            let resolved = self
+                .interpolate(&part.content, true, Some(&body), depth)
+                .await?;
+            parts.push((part.name.clone(), resolved));
+        }
+
+        Ok(Prepared {
+            url,
+            headers,
+            body,
+            multipart: parts,
+        })
     }
 
     #[async_recursion]
-    async fn execute(&self, req: &Request) -> Result<(String, String, String), Box<dyn Error>> {
-        let url = self.handle_variables_and_hooks(req.path.clone()).await;
+    async fn execute(&self, req: &Request, depth: usize) -> Result<(String, String, String), String> {
+        let prepared = self.prepare(req, depth).await?;
 
-        let mut headers = req.headers.clone();
-        for (key, value) in &req.headers {
-            let normalized = self.handle_variables_and_hooks(value.clone()).await;
-            headers.insert(key.clone(), normalized.clone());
-        }
-
-        let mut new = Request::new(
-            req.method.clone(),
-            url.clone(),
-            req.body.clone(),
-            req.multipart.clone(),
-        );
-
-        if !headers.is_empty() {
-            new.set_headers(headers);
-        }
-
-        let http_method = new.format_method();
         let mut http_headers = HeaderMap::new();
-        for (key, value) in new.headers.clone() {
-            http_headers.insert(
-                HeaderName::from_bytes(key.as_bytes()).unwrap(),
-                HeaderValue::from_str(value.as_str()).unwrap(),
-            );
+        for (key, value) in &prepared.headers {
+            let header_name = HeaderName::from_bytes(key.as_bytes())
+                .map_err(|_| format!("invalid header name `{}`", key))?;
+            let header_value = HeaderValue::from_str(value)
+                .map_err(|_| format!("invalid value for header `{}`: `{}`", key, value))?;
+            http_headers.insert(header_name, header_value);
         }
 
-        let mut multipart: Option<multipart::Form> = None;
-
-        let new_multipart = new.multipart.clone();
-        if new_multipart.len() > 0 {
+        let mut form: Option<multipart::Form> = None;
+        if !prepared.multipart.is_empty() {
             let mut m = multipart::Form::new();
 
-            for part in new_multipart.iter() {
-                if part.content.starts_with("download://") {
-                    let path_str = part.content.clone().replace("download://", "");
-                    let bytes = reqwest::get(path_str.clone()).await?.bytes().await?;
-                    let file_name = Url::parse(path_str.clone().as_str())
-                        .unwrap()
-                        .path_segments()
-                        .unwrap()
-                        .last()
-                        .unwrap_or("file")
+            for (name, content) in &prepared.multipart {
+                if let Some(download_url) = content.strip_prefix("download://") {
+                    let response = reqwest::get(download_url).await.map_err(|e| {
+                        format!("cannot download `{}`: {}", download_url, describe(&e))
+                    })?;
+                    let bytes = response.bytes().await.map_err(|e| {
+                        format!("cannot download `{}`: {}", download_url, describe(&e))
+                    })?;
+                    let file_name = Url::parse(download_url)
+                        .ok()
+                        .and_then(|u| {
+                            u.path_segments()
+                                .and_then(|s| s.last().map(|s| s.to_string()))
+                        })
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "file".to_string());
+
+                    let mime = from_path(download_url).first_or_octet_stream();
+                    let part = Part::bytes(bytes.to_vec())
+                        .file_name(file_name)
+                        .mime_str(mime.as_ref())
+                        .map_err(|e| format!("invalid mime type for `{}`: {}", name, e))?;
+                    m = m.part(name.clone(), part);
+                } else if let Some(path_str) = content.strip_prefix("file://") {
+                    let path = Path::new(path_str);
+                    let file_name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .ok_or(format!("invalid file path `{}`", path_str))?
                         .to_string();
+                    let content = fs::read(path)
+                        .map_err(|e| format!("cannot read file `{}`: {}", path_str, e))?;
 
-                    let mime = from_path(&path_str.as_str()).first_or_octet_stream();
-
-                    let file_part = Part::bytes(bytes.to_vec())
-                        .file_name(file_name.clone())
+                    let mime = from_path(path).first_or_octet_stream();
+                    let part = Part::bytes(content)
+                        .file_name(file_name)
                         .mime_str(mime.as_ref())
-                        .ok();
-                    m = m.part(part.name.clone(), file_part.unwrap());
-                } else if part.content.starts_with("file://") {
-                    let path_str = part.content.clone().replace("file://", "");
-                    let path = Path::new(&path_str);
-                    let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
-                    let content: Vec<u8> = fs::read(path).unwrap();
-
-                    let mime = from_path(&path).first_or_octet_stream();
-
-                    let file_part = Part::bytes(content)
-                        .file_name(file_name.clone())
-                        .mime_str(mime.as_ref())
-                        .ok();
-
-                    m = m.part(part.name.clone(), file_part.unwrap());
+                        .map_err(|e| format!("invalid mime type for `{}`: {}", name, e))?;
+                    m = m.part(name.clone(), part);
                 } else {
-                    m = m.text(part.name.clone(), part.content.to_string());
+                    m = m.text(name.clone(), content.clone());
                 }
             }
 
-            multipart = Some(m);
+            form = Some(m);
+            // reqwest sets the multipart boundary itself
             http_headers.remove("Content-Type");
         }
 
         let client = Client::new();
+        let request = client
+            .request(req.format_method(), &prepared.url)
+            .headers(http_headers);
 
-        let response = if multipart.is_some() {
-            client
-                .request(http_method, new.path)
-                .headers(http_headers)
-                .multipart(multipart.unwrap())
-                .send()
-                .await?
-        } else {
-            client
-                .request(http_method, new.path)
-                .body(new.body)
-                .headers(http_headers)
-                .send()
-                .await?
+        let request = match form {
+            Some(f) => request.multipart(f),
+            None => request.body(prepared.body.clone()),
         };
 
+        let response = request.send().await.map_err(|e| describe(&e))?;
         let status = response.status();
+        let body = response.text().await.map_err(|e| describe(&e))?;
 
-        let body = response.text().await?;
-        Ok((status.to_string(), url, body))
+        Ok((status.to_string(), prepared.url, body))
     }
 
-    pub fn from_file(&mut self, filename: String) {
+    pub fn from_file(&mut self, filename: String) -> Result<(), String> {
         self.filename = filename.clone();
+
+        let content = fs::read_to_string(&filename)
+            .map_err(|e| format!("cannot read `{}`: {}", filename, e))?;
+
         let mut context = "VARS";
         let mut last_id: String = String::new();
         let mut request_body: String = String::new();
-        for line in fs::read_to_string(filename).unwrap().lines() {
-            let mut line = line.to_string();
-            if line.trim().starts_with("#") {
+
+        for (index, raw_line) in content.lines().enumerate() {
+            let ln = index + 1;
+            let line = raw_line.trim();
+
+            if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            if line.starts_with("VARS") {
+
+            if line == "VARS" {
                 context = "VARS";
-            } else if line.starts_with("HOOKS") {
+            } else if line == "HOOKS" {
                 context = "HOOKS";
-            } else if line.starts_with("ID:") {
+            } else if let Some(id) = line.strip_prefix("ID:") {
                 context = "REQUEST";
-                if request_body != "" {
-                    let req = self.requests.get_mut(&last_id).unwrap();
-                    req.set_body(request_body);
+                if !request_body.is_empty() {
+                    self.requests.get_mut(&last_id).unwrap().set_body(request_body);
                     request_body = String::new();
                 }
-                last_id = line.split(":").collect::<Vec<&str>>()[1].trim().to_string();
-                self.add_request(last_id.clone(), Request::default());
+                last_id = id.trim().to_string();
+                if last_id.is_empty() {
+                    return Err(self.parse_error(ln, raw_line, "requests need an id, e.g. `ID: login`"));
+                }
+                if self.requests.contains_key(&last_id) {
+                    return Err(self.parse_error(
+                        ln,
+                        raw_line,
+                        &format!("duplicate request id `{}`", last_id),
+                    ));
+                }
+                self.requests.insert(last_id.clone(), Request::default());
+                self.order.push(last_id.clone());
+            } else if context == "VARS" {
+                let (key, value) = split_key_value(line).ok_or_else(|| {
+                    self.parse_error(ln, raw_line, "variables use `name = value`")
+                })?;
+
+                let mut value = value;
+                if let Some(var) = value.strip_prefix("$env.") {
+                    value = env::var(var).map_err(|_| {
+                        self.parse_error(
+                            ln,
+                            raw_line,
+                            &format!("environment variable `{}` is not set", var),
+                        )
+                    })?;
+                }
+
+                self.variables.insert(key, strip_quotes(&value));
+            } else if context == "HOOKS" {
+                let (key, value) = split_key_value(line).ok_or_else(|| {
+                    self.parse_error(
+                        ln,
+                        raw_line,
+                        "hooks use `name = $req.<request-id> [cache-seconds]`",
+                    )
+                })?;
+                self.hooks.insert(key, value);
             } else {
-                if line.trim() == "" {
-                    continue;
-                }
-
-                if context == "VARS" {
-                    let parts = line.split("=").collect::<Vec<&str>>();
-                    if parts.len() != 2 {
-                        panic!("invalid variable provided {}", line);
-                    }
-                    let mut value = parts[1].trim().to_string();
-                    if value.starts_with("$env.") {
-                        value = env::var(value.replace("$env.", "")).unwrap();
-                    }
-
-                    if value.starts_with('"') && value.ends_with('"')
-                        || value.starts_with("'") && value.ends_with("'")
-                    {
-                        value = value.replace('"', "").replace("'", "");
-                    }
-
-                    self.add_variable(parts[0].trim().to_string(), value);
-                }
-                if context == "HOOKS" {
-                    let parts = line.split("=").collect::<Vec<&str>>();
-                    self.add_hook(parts[0].trim().to_string(), parts[1].trim().to_string());
-                }
-
-                if context == "REQUEST" {
+                // context == "REQUEST"
+                if let Some(rest) = line.strip_prefix("H:") {
+                    let (key, value) = split_key_value(rest).ok_or_else(|| {
+                        self.parse_error(ln, raw_line, "headers use `H: Name = value`")
+                    })?;
                     let req = self.requests.get_mut(&last_id).unwrap();
-                    if line.starts_with("H:") {
-                        line = line.replace("H:", "");
-                        let parts = line.split("=").collect::<Vec<&str>>();
-                        if parts.len() != 2 {
-                            panic!("invalid header provided {}", line);
-                        }
-                        let key = parts[0].trim().to_string();
-                        let value = parts[1].trim().to_string();
-                        req.add_header(key, value);
-                        continue;
+                    req.add_header(key, strip_quotes(&value));
+                } else if let Some(rest) = line.strip_prefix("M:") {
+                    let (key, value) = split_key_value(rest).ok_or_else(|| {
+                        self.parse_error(ln, raw_line, "multipart fields use `M: name = value`")
+                    })?;
+                    let req = self.requests.get_mut(&last_id).unwrap();
+                    req.add_multipart(key, value);
+                } else if is_method_line(line) {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() != 2 {
+                        return Err(self.parse_error(
+                            ln,
+                            raw_line,
+                            "request lines use `METHOD url`, e.g. `GET $baseURL/users`",
+                        ));
                     }
-
-                    if line.starts_with("M:") {
-                        line = line.replace("M:", "");
-                        let parts = line.split("=").collect::<Vec<&str>>();
-                        if parts.len() < 2 {
-                            panic!("invalid multipart form provided {}", line);
-                        }
-                        let key = parts[0].trim().to_string();
-                        let value = parts[1..].join("=").trim().to_string();
-                        req.add_multipart(key.clone(), value);
-                        continue;
+                    let req = self.requests.get_mut(&last_id).unwrap();
+                    req.set_method(parts[0].to_string());
+                    req.set_path(parts[1].to_string());
+                } else {
+                    if self.requests[&last_id].method.is_empty() {
+                        return Err(self.parse_error(
+                            ln,
+                            raw_line,
+                            &format!(
+                                "request `{}` needs a `METHOD url` line before its body",
+                                last_id
+                            ),
+                        ));
                     }
-
-                    if line.starts_with("GET")
-                        || line.starts_with("POST")
-                        || line.starts_with("PUT")
-                        || line.starts_with("DELETE")
-                        || line.starts_with("PATCH")
-                        || line.starts_with("HEAD")
-                        || line.starts_with("OPTIONS")
-                    {
-                        let parts: Vec<&str> = line.split(" ").collect::<Vec<&str>>();
-                        if parts.len() != 2 {
-                            panic!("invalid request provided {}", line);
-                        }
-                        req.set_method(parts[0].trim().to_string());
-                        req.set_path(parts[1].trim().to_string());
-                        continue;
-                    }
-
-                    request_body.push_str(&line.trim().to_string());
+                    request_body.push_str(line);
                 }
             }
         }
-        if request_body != "" {
-            let req = self.requests.get_mut(&last_id).unwrap();
-            req.set_body(request_body);
+
+        if !request_body.is_empty() {
+            self.requests.get_mut(&last_id).unwrap().set_body(request_body);
         }
+
+        for id in &self.order {
+            if self.requests[id].method.is_empty() {
+                return Err(format!(
+                    "request `{}` in {} has no `METHOD url` line",
+                    id, filename
+                ));
+            }
+        }
+
+        Ok(())
     }
 
-    fn add_request(&mut self, id: String, request: Request) {
-        self.requests.insert(id, request);
+    fn parse_error(&self, line_number: usize, line: &str, hint: &str) -> String {
+        format!(
+            "invalid line {} of {}:\n  {}\n  {} {}",
+            line_number,
+            self.filename,
+            line.trim(),
+            "hint:".bold(),
+            hint
+        )
+    }
+}
+
+/// Splits `key = value` on the FIRST `=` only, so values containing `=`
+/// (base64, signatures, urls) survive intact. Rejects keys that aren't a
+/// single bare word, which catches lines missing their `=` separator.
+fn split_key_value(line: &str) -> Option<(String, String)> {
+    let (key, value) = line.split_once('=')?;
+    let key = key.trim();
+    if key.is_empty()
+        || !key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return None;
+    }
+    Some((key.to_string(), value.trim().to_string()))
+}
+
+/// Removes one pair of matching surrounding quotes, leaving inner quotes alone.
+fn strip_quotes(value: &str) -> String {
+    let bytes = value.as_bytes();
+    if value.len() >= 2
+        && (bytes[0] == b'"' && bytes[value.len() - 1] == b'"'
+            || bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'')
+    {
+        return value[1..value.len() - 1].to_string();
+    }
+    value.to_string()
+}
+
+fn is_method_line(line: &str) -> bool {
+    ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+        .iter()
+        .any(|m| line.starts_with(m))
+}
+
+fn describe(e: &reqwest::Error) -> String {
+    // reqwest errors nest the same cause several times; report the message
+    // plus the root cause only.
+    let mut root = None;
+    let mut source = e.source();
+    while let Some(s) = source {
+        root = Some(s.to_string());
+        source = s.source();
     }
 
-    fn add_variable(&mut self, name: String, value: String) {
-        self.variables.insert(name, value);
-    }
-
-    fn add_hook(&mut self, id: String, value: String) {
-        self.hooks.insert(id, value);
+    let msg = e.to_string();
+    match root {
+        Some(cause) if !msg.contains(&cause) => format!("{}: {}", msg, cause),
+        _ => msg,
     }
 }

--- a/src/lazyreq.rs
+++ b/src/lazyreq.rs
@@ -85,28 +85,53 @@ impl LazyReq {
             .await
             .map_err(|e| format!("request `{}` failed:\n  {}", id, e))?;
 
-        let status_colored = match status.chars().next() {
-            Some('2') => status.bold().green(),
-            Some('3') => status.bold().yellow(),
-            _ => status.bold().red(),
+        print_response(&req.method, &url, &status, &result);
+        Ok(())
+    }
+
+    /// Replays a recorded run: the recorded URL and body verbatim (fuzzed
+    /// values and all), with headers re-resolved from the current request
+    /// definition so auth hooks produce fresh tokens.
+    pub async fn retry(&self, run_id: String) -> Result<(), String> {
+        let rec = history::find(&self.filename, &run_id)?.ok_or(format!(
+            "no run `{}` in the history of {} (use --history to see run ids)",
+            run_id, self.filename
+        ))?;
+
+        let headers = match self.requests.get(&rec.id) {
+            Some(def) if !def.multipart.is_empty() => {
+                return Err(format!(
+                    "request `{}` uploads multipart data, which history does not store — run `lazyreq {} {}` instead",
+                    rec.id, self.filename, rec.id
+                ));
+            }
+            Some(def) => {
+                let mut resolved = HashMap::new();
+                for (key, value) in &def.headers {
+                    let value = self
+                        .interpolate(value, true, Some(&rec.req_body), 0)
+                        .await?;
+                    resolved.insert(key.clone(), value);
+                }
+                resolved
+            }
+            None => {
+                eprintln!(
+                    "{} request `{}` is no longer in {}; replaying its recorded headers (auth may be stale)",
+                    "note:".yellow().bold(),
+                    rec.id,
+                    self.filename
+                );
+                rec.req_headers.clone()
+            }
         };
 
-        println!(
-            "{}{}{} {}",
-            "[".bold().green(),
-            req.method.bold().green(),
-            "]".bold().green(),
-            url.bold().green()
-        );
-        println!("{} {}", "Status:".bold().green(), status_colored);
+        let (status, url, result) = self
+            .send_recorded(&rec.id, &rec.method, &rec.url, &headers, &rec.req_body, None)
+            .await
+            .map_err(|e| format!("retry of run `{}` (request `{}`) failed:\n  {}", run_id, rec.id, e))?;
 
-        let pretty_json: Value = serde_json::from_str(result.as_str()).unwrap_or(Value::Null);
-        if !pretty_json.is_null() {
-            println!("{}", to_string_pretty(&pretty_json).unwrap());
-        } else {
-            println!("{}", result);
-        }
-
+        print_response(&rec.method, &url, &status, &result);
         Ok(())
     }
 
@@ -416,15 +441,6 @@ impl LazyReq {
     ) -> Result<(String, String, String), String> {
         let prepared = self.prepare(req, depth).await?;
 
-        let mut http_headers = HeaderMap::new();
-        for (key, value) in &prepared.headers {
-            let header_name = HeaderName::from_bytes(key.as_bytes())
-                .map_err(|_| format!("invalid header name `{}`", key))?;
-            let header_value = HeaderValue::from_str(value)
-                .map_err(|_| format!("invalid value for header `{}`: `{}`", key, value))?;
-            http_headers.insert(header_name, header_value);
-        }
-
         let mut form: Option<multipart::Form> = None;
         if !prepared.multipart.is_empty() {
             let mut m = multipart::Form::new();
@@ -474,18 +490,50 @@ impl LazyReq {
             }
 
             form = Some(m);
+        }
+
+        self.send_recorded(
+            id,
+            &req.method,
+            &prepared.url,
+            &prepared.headers,
+            &prepared.body,
+            form,
+        )
+        .await
+    }
+
+    /// Sends a fully-resolved request and records the run in history.
+    async fn send_recorded(
+        &self,
+        id: &str,
+        method: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+        body: &str,
+        form: Option<multipart::Form>,
+    ) -> Result<(String, String, String), String> {
+        let mut http_headers = HeaderMap::new();
+        for (key, value) in headers {
+            let header_name = HeaderName::from_bytes(key.as_bytes())
+                .map_err(|_| format!("invalid header name `{}`", key))?;
+            let header_value = HeaderValue::from_str(value)
+                .map_err(|_| format!("invalid value for header `{}`: `{}`", key, value))?;
+            http_headers.insert(header_name, header_value);
+        }
+        if form.is_some() {
             // reqwest sets the multipart boundary itself
             http_headers.remove("Content-Type");
         }
 
         let client = Client::new();
         let request = client
-            .request(req.format_method(), &prepared.url)
+            .request(crate::request::parse_method(method), url)
             .headers(http_headers);
 
         let request = match form {
             Some(f) => request.multipart(f),
-            None => request.body(prepared.body.clone()),
+            None => request.body(body.to_string()),
         };
 
         let record = |status: u16, ms: u64, resp_body: &str, error: Option<String>| {
@@ -493,14 +541,15 @@ impl LazyReq {
                 &self.filename,
                 history::Record {
                     v: 1,
+                    req: history::new_run_id(),
                     ts: get_timestamp(),
                     id: id.to_string(),
-                    method: req.method.to_uppercase(),
-                    url: prepared.url.clone(),
+                    method: method.to_uppercase(),
+                    url: url.to_string(),
                     status,
                     ms,
-                    req_headers: prepared.headers.clone(),
-                    req_body: prepared.body.clone(),
+                    req_headers: headers.clone(),
+                    req_body: body.to_string(),
                     resp_body: resp_body.to_string(),
                     error,
                 },
@@ -531,7 +580,7 @@ impl LazyReq {
         };
 
         record(status.as_u16(), ms, &body, None);
-        Ok((status.to_string(), prepared.url, body))
+        Ok((status.to_string(), url.to_string(), body))
     }
 
     pub fn from_file(&mut self, filename: String) -> Result<(), String> {
@@ -671,6 +720,30 @@ impl LazyReq {
             "hint:".bold(),
             hint
         )
+    }
+}
+
+fn print_response(method: &str, url: &str, status: &str, result: &str) {
+    let status_colored = match status.chars().next() {
+        Some('2') => status.bold().green(),
+        Some('3') => status.bold().yellow(),
+        _ => status.bold().red(),
+    };
+
+    println!(
+        "{}{}{} {}",
+        "[".bold().green(),
+        method.bold().green(),
+        "]".bold().green(),
+        url.bold().green()
+    );
+    println!("{} {}", "Status:".bold().green(), status_colored);
+
+    let pretty_json: Value = serde_json::from_str(result).unwrap_or(Value::Null);
+    if !pretty_json.is_null() {
+        println!("{}", to_string_pretty(&pretty_json).unwrap());
+    } else {
+        println!("{}", result);
     }
 }
 

--- a/src/lazyreq.rs
+++ b/src/lazyreq.rs
@@ -14,7 +14,9 @@ use std::{env, fs};
 
 use crate::cache::Cache;
 use crate::functions;
+use crate::history;
 use crate::request::Request;
+use crate::timest::get_timestamp;
 
 const MAX_DEPTH: usize = 16;
 const TOKEN_PATTERN: &str = r"\$\$|\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*(?:\([^)]*\))?";
@@ -79,7 +81,7 @@ impl LazyReq {
         ))?;
 
         let (status, url, result) = self
-            .execute(req, 0)
+            .execute(&id, req, 0)
             .await
             .map_err(|e| format!("request `{}` failed:\n  {}", id, e))?;
 
@@ -350,7 +352,7 @@ impl LazyReq {
         ))?;
 
         let (status, _, result) = self
-            .execute(req, depth + 1)
+            .execute(req_id, req, depth + 1)
             .await
             .map_err(|e| format!("hook `{}` (request `{}`) failed: {}", name, req_id, e))?;
 
@@ -406,7 +408,12 @@ impl LazyReq {
     }
 
     #[async_recursion]
-    async fn execute(&self, req: &Request, depth: usize) -> Result<(String, String, String), String> {
+    async fn execute(
+        &self,
+        id: &str,
+        req: &Request,
+        depth: usize,
+    ) -> Result<(String, String, String), String> {
         let prepared = self.prepare(req, depth).await?;
 
         let mut http_headers = HeaderMap::new();
@@ -481,10 +488,49 @@ impl LazyReq {
             None => request.body(prepared.body.clone()),
         };
 
-        let response = request.send().await.map_err(|e| describe(&e))?;
-        let status = response.status();
-        let body = response.text().await.map_err(|e| describe(&e))?;
+        let record = |status: u16, ms: u64, resp_body: &str, error: Option<String>| {
+            history::record(
+                &self.filename,
+                history::Record {
+                    v: 1,
+                    ts: get_timestamp(),
+                    id: id.to_string(),
+                    method: req.method.to_uppercase(),
+                    url: prepared.url.clone(),
+                    status,
+                    ms,
+                    req_headers: prepared.headers.clone(),
+                    req_body: prepared.body.clone(),
+                    resp_body: resp_body.to_string(),
+                    error,
+                },
+            );
+        };
 
+        let started = std::time::Instant::now();
+        let response = request.send().await;
+        let ms = started.elapsed().as_millis() as u64;
+
+        let response = match response {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = describe(&e);
+                record(0, ms, "", Some(msg.clone()));
+                return Err(msg);
+            }
+        };
+
+        let status = response.status();
+        let body = match response.text().await {
+            Ok(b) => b,
+            Err(e) => {
+                let msg = describe(&e);
+                record(status.as_u16(), ms, "", Some(msg.clone()));
+                return Err(msg);
+            }
+        };
+
+        record(status.as_u16(), ms, &body, None);
         Ok((status.to_string(), prepared.url, body))
     }
 
@@ -676,5 +722,141 @@ fn describe(e: &reqwest::Error) -> String {
     match root {
         Some(cause) if !msg.contains(&cause) => format!("{}: {}", msg, cause),
         _ => msg,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn load(content: &str) -> Result<LazyReq, String> {
+        let path = std::env::temp_dir().join(format!("lazyreq-test-{}.lreq", uuid::Uuid::new_v4()));
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+
+        let mut lazyreq = LazyReq::new();
+        let result = lazyreq.from_file(path.to_string_lossy().to_string());
+        let _ = fs::remove_file(&path);
+        result.map(|_| lazyreq)
+    }
+
+    const DEMO: &str = "VARS
+  baseURL = http://localhost:8080
+  quoted = \"with spaces\"
+
+HOOKS
+  login = $req.login 30
+
+ID: login
+POST $baseURL/login
+H: Content-Type = application/json
+{\"email\": \"a@b.c\"}
+
+ID: me
+DESCRIPTION: Current user
+GET $baseURL/users/me
+H: Authorization = Bearer $login.token
+";
+
+    #[test]
+    fn parses_vars_hooks_and_requests() {
+        let lazyreq = load(DEMO).unwrap();
+
+        assert_eq!(lazyreq.variables["baseURL"], "http://localhost:8080");
+        assert_eq!(lazyreq.variables["quoted"], "with spaces"); // quotes stripped
+        assert_eq!(lazyreq.hooks["login"], "$req.login 30");
+        assert_eq!(lazyreq.order, vec!["login", "me"]);
+
+        let login = &lazyreq.requests["login"];
+        assert_eq!(login.method, "POST");
+        assert_eq!(login.path, "$baseURL/login");
+        assert_eq!(login.body, "{\"email\": \"a@b.c\"}");
+
+        let me = &lazyreq.requests["me"];
+        assert_eq!(me.description, "Current user");
+        assert_eq!(me.headers["Authorization"], "Bearer $login.token");
+    }
+
+    #[test]
+    fn parse_errors_carry_line_numbers_and_hints() {
+        let err = load("ID: a\nGET http://x.dev\n\nID: a\nGET http://x.dev\n").err().unwrap();
+        assert!(err.contains("duplicate request id `a`"));
+        assert!(err.contains("line 4"));
+
+        let err = load("ID: a\nsome body before method\n").err().unwrap();
+        assert!(err.contains("needs a `METHOD url` line"));
+
+        let err = load("ID: a\n").err().unwrap();
+        assert!(err.contains("no `METHOD url` line"));
+
+        let err = load("ID:\nGET http://x.dev\n").err().unwrap();
+        assert!(err.contains("requests need an id"));
+    }
+
+    #[tokio::test]
+    async fn interpolates_vars_env_and_escapes() {
+        let lazyreq = load(DEMO).unwrap();
+
+        let url = lazyreq
+            .interpolate("$baseURL/users?q=$quoted", true, None, 0)
+            .await
+            .unwrap();
+        assert_eq!(url, "http://localhost:8080/users?q=with spaces");
+
+        std::env::set_var("LAZYREQ_TEST_TOKEN", "t-123");
+        let header = lazyreq
+            .interpolate("Bearer $env.LAZYREQ_TEST_TOKEN", true, None, 0)
+            .await
+            .unwrap();
+        assert_eq!(header, "Bearer t-123");
+
+        let literal = lazyreq.interpolate("costs $$5", true, None, 0).await.unwrap();
+        assert_eq!(literal, "costs $5");
+    }
+
+    #[tokio::test]
+    async fn strict_and_lenient_unknown_tokens() {
+        let lazyreq = load(DEMO).unwrap();
+
+        // URLs and headers reject unknown tokens...
+        assert!(lazyreq.interpolate("$nope", true, None, 0).await.is_err());
+        // ...bodies pass them through so JSON dollar-words keep working
+        let body = lazyreq
+            .interpolate("{\"filter\": {\"$gte\": 5}}", false, None, 0)
+            .await
+            .unwrap();
+        assert_eq!(body, "{\"filter\": {\"$gte\": 5}}");
+    }
+
+    #[tokio::test]
+    async fn body_token_resolves_for_signing() {
+        let lazyreq = load(DEMO).unwrap();
+
+        let signed = lazyreq
+            .interpolate("sig of $body", true, Some("{\"a\":1}"), 0)
+            .await
+            .unwrap();
+        assert_eq!(signed, "sig of {\"a\":1}");
+        // ...but is an error where no body exists yet
+        assert!(lazyreq.interpolate("$body", true, None, 0).await.is_err());
+    }
+
+    #[test]
+    fn split_key_value_splits_on_first_equals_only() {
+        assert_eq!(
+            split_key_value("Authorization = abc=def=="),
+            Some(("Authorization".to_string(), "abc=def==".to_string()))
+        );
+        assert_eq!(split_key_value("no separator"), None);
+        assert_eq!(split_key_value("two words = x"), None);
+    }
+
+    #[test]
+    fn strip_quotes_removes_one_matching_pair() {
+        assert_eq!(strip_quotes("\"hello\""), "hello");
+        assert_eq!(strip_quotes("'hello'"), "hello");
+        assert_eq!(strip_quotes("\"mismatched'"), "\"mismatched'");
+        assert_eq!(strip_quotes("\"\"inner\"\""), "\"inner\"");
     }
 }

--- a/src/lazyreq.rs
+++ b/src/lazyreq.rs
@@ -56,11 +56,17 @@ impl LazyReq {
 
         for id in &self.order {
             let req = &self.requests[id];
+            let description = if req.description.is_empty() {
+                "".normal()
+            } else {
+                format!("  — {}", req.description).dimmed()
+            };
             println!(
-                "{:width$}  {:7} {}",
+                "{:width$}  {:7} {}{}",
                 id.bold().green(),
                 req.method,
                 req.path,
+                description,
                 width = width
             );
         }
@@ -551,7 +557,10 @@ impl LazyReq {
                 self.hooks.insert(key, value);
             } else {
                 // context == "REQUEST"
-                if let Some(rest) = line.strip_prefix("H:") {
+                if let Some(rest) = line.strip_prefix("DESCRIPTION:") {
+                    let req = self.requests.get_mut(&last_id).unwrap();
+                    req.set_description(rest.trim().to_string());
+                } else if let Some(rest) = line.strip_prefix("H:") {
                     let (key, value) = split_key_value(rest).ok_or_else(|| {
                         self.parse_error(ln, raw_line, "headers use `H: Name = value`")
                     })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 use std::env;
+use std::process::exit;
 
-use config::Config;
+use colored::*;
+use config::{Config, Mode};
 use lazyreq::LazyReq;
 
 mod cache;
 mod config;
+mod functions;
 mod lazyreq;
 mod request;
 mod timest;
@@ -13,14 +16,23 @@ mod timest;
 async fn main() {
     let args: Vec<String> = env::args().collect();
 
-    let config = Config::new(&args);
+    if let Err(msg) = run(&args).await {
+        eprintln!("{} {}", "error:".red().bold(), msg);
+        exit(1);
+    }
+}
+
+async fn run(args: &[String]) -> Result<(), String> {
+    let config = Config::new(args)?;
 
     let mut lazyreq = LazyReq::new();
-    lazyreq.from_file(config.filename);
-    
-    if config.export_curl {
-        lazyreq.export_curl(config.target).await;
-    } else {
-        lazyreq.do_request(config.target).await;
+    lazyreq.from_file(config.filename)?;
+
+    match config.mode {
+        Mode::List => lazyreq.list(),
+        Mode::ExportCurl => lazyreq.export_curl(config.target).await?,
+        Mode::Run => lazyreq.do_request(config.target).await?,
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn run(args: &[String]) -> Result<(), String> {
         Mode::Import(_) | Mode::Version | Mode::History(_) => unreachable!(),
         Mode::List => lazyreq.list(),
         Mode::ExportCurl => lazyreq.export_curl(config.target).await?,
+        Mode::Retry(run_id) => lazyreq.retry(run_id).await?,
         Mode::Run => lazyreq.do_request(config.target).await?,
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,11 @@ async fn main() {
 async fn run(args: &[String]) -> Result<(), String> {
     let config = Config::new(args)?;
 
+    if let Mode::Version = config.mode {
+        println!("lazyreq {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     if let Mode::Import(command) = &config.mode {
         print!("{}", import::curl_to_lreq(command)?);
         return Ok(());
@@ -35,7 +40,7 @@ async fn run(args: &[String]) -> Result<(), String> {
     lazyreq.from_file(config.filename)?;
 
     match config.mode {
-        Mode::Import(_) => unreachable!(),
+        Mode::Import(_) | Mode::Version => unreachable!(),
         Mode::List => lazyreq.list(),
         Mode::ExportCurl => lazyreq.export_curl(config.target).await?,
         Mode::Run => lazyreq.do_request(config.target).await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@ use lazyreq::LazyReq;
 mod cache;
 mod config;
 mod functions;
+mod history;
 mod import;
 mod lazyreq;
 mod request;
 mod timest;
+mod vault;
 
 #[tokio::main]
 async fn main() {
@@ -36,11 +38,18 @@ async fn run(args: &[String]) -> Result<(), String> {
         return Ok(());
     }
 
+    if let Mode::History(opts) = &config.mode {
+        // History only needs the file's identity, not a successful parse —
+        // past runs stay readable even while the file is mid-edit.
+        let id = (!config.target.is_empty()).then_some(config.target.as_str());
+        return history::show(&config.filename, id, opts);
+    }
+
     let mut lazyreq = LazyReq::new();
     lazyreq.from_file(config.filename)?;
 
     match config.mode {
-        Mode::Import(_) | Mode::Version => unreachable!(),
+        Mode::Import(_) | Mode::Version | Mode::History(_) => unreachable!(),
         Mode::List => lazyreq.list(),
         Mode::ExportCurl => lazyreq.export_curl(config.target).await?,
         Mode::Run => lazyreq.do_request(config.target).await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use lazyreq::LazyReq;
 mod cache;
 mod config;
 mod functions;
+mod import;
 mod lazyreq;
 mod request;
 mod timest;
@@ -25,10 +26,16 @@ async fn main() {
 async fn run(args: &[String]) -> Result<(), String> {
     let config = Config::new(args)?;
 
+    if let Mode::Import(command) = &config.mode {
+        print!("{}", import::curl_to_lreq(command)?);
+        return Ok(());
+    }
+
     let mut lazyreq = LazyReq::new();
     lazyreq.from_file(config.filename)?;
 
     match config.mode {
+        Mode::Import(_) => unreachable!(),
         Mode::List => lazyreq.list(),
         Mode::ExportCurl => lazyreq.export_curl(config.target).await?,
         Mode::Run => lazyreq.do_request(config.target).await?,

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,7 @@ pub struct MultiPart {
 impl Request {
     pub fn default() -> Request {
         Request {
-            method: "NOT SET".to_string(),
+            method: "".to_string(),
             path: "".to_string(),
             headers: HashMap::new(),
             body: "".to_string(),
@@ -40,16 +40,6 @@ impl Request {
         }
     }
 
-    pub fn new(method: String, path: String, body: String, multipart: Vec<MultiPart>) -> Request {
-        Request {
-            method,
-            path,
-            headers: HashMap::new(),
-            body,
-            multipart,
-        }
-    }
-
     pub fn add_header(&mut self, name: String, value: String) {
         self.headers.insert(name, value);
     }
@@ -59,10 +49,6 @@ impl Request {
             name,
             content: value,
         });
-    }
-
-    pub fn set_headers(&mut self, headers: HashMap<String, String>) {
-        self.headers = headers;
     }
 
     pub fn set_method(&mut self, method: String) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,6 +5,7 @@ use reqwest::Method;
 pub struct Request {
     pub method: String,
     pub path: String,
+    pub description: String,
     pub headers: HashMap<String, String>,
     pub body: String,
     pub multipart: Vec<MultiPart>,
@@ -21,6 +22,7 @@ impl Request {
         Request {
             method: "".to_string(),
             path: "".to_string(),
+            description: "".to_string(),
             headers: HashMap::new(),
             body: "".to_string(),
             multipart: Vec::new(),
@@ -49,6 +51,10 @@ impl Request {
             name,
             content: value,
         });
+    }
+
+    pub fn set_description(&mut self, description: String) {
+        self.description = description;
     }
 
     pub fn set_method(&mut self, method: String) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -17,6 +17,19 @@ pub struct MultiPart {
     pub content: String,
 }
 
+pub fn parse_method(method: &str) -> Method {
+    match method.to_uppercase().as_str() {
+        "GET" => Method::GET,
+        "POST" => Method::POST,
+        "PUT" => Method::PUT,
+        "DELETE" => Method::DELETE,
+        "PATCH" => Method::PATCH,
+        "HEAD" => Method::HEAD,
+        "OPTIONS" => Method::OPTIONS,
+        _ => Method::GET, // Default to GET if unknown
+    }
+}
+
 impl Request {
     pub fn default() -> Request {
         Request {
@@ -26,19 +39,6 @@ impl Request {
             headers: HashMap::new(),
             body: "".to_string(),
             multipart: Vec::new(),
-        }
-    }
-
-    pub fn format_method(&self) -> Method {
-        match self.method.to_uppercase().as_str() {
-            "GET" => Method::GET,
-            "POST" => Method::POST,
-            "PUT" => Method::PUT,
-            "DELETE" => Method::DELETE,
-            "PATCH" => Method::PATCH,
-            "HEAD" => Method::HEAD,
-            "OPTIONS" => Method::OPTIONS,
-            _ => Method::GET, // Default to GET if unknown
         }
     }
 

--- a/src/timest.rs
+++ b/src/timest.rs
@@ -15,3 +15,50 @@ pub fn is_older_than(timestamp: u64) -> bool {
 pub fn add_seconds(timestamp: u64, seconds: u64) -> u64 {
     timestamp + seconds
 }
+
+/// Unix timestamp → `YYYY-MM-DD HH:MM:SS` (UTC), without pulling in chrono.
+pub fn format_timestamp(timestamp: u64) -> String {
+    let days = (timestamp / 86_400) as i64;
+    let secs = timestamp % 86_400;
+
+    // Howard Hinnant's civil_from_days algorithm.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = yoe as i64 + era * 400 + if month <= 2 { 1 } else { 0 };
+
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        year,
+        month,
+        day,
+        secs / 3_600,
+        (secs % 3_600) / 60,
+        secs % 60
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_known_timestamps() {
+        assert_eq!(format_timestamp(0), "1970-01-01 00:00:00");
+        assert_eq!(format_timestamp(951_827_696), "2000-02-29 12:34:56"); // leap day
+        assert_eq!(format_timestamp(1_783_987_601), "2026-07-14 00:06:41");
+        assert_eq!(format_timestamp(4_102_444_799), "2099-12-31 23:59:59");
+    }
+
+    #[test]
+    fn expiry_helpers() {
+        assert_eq!(add_seconds(100, 30), 130);
+        assert!(is_older_than(get_timestamp() - 10));
+        assert!(!is_older_than(get_timestamp() + 10));
+    }
+}

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -1,0 +1,187 @@
+//! Encrypted-at-rest storage for everything under `~/.lazyreq` (hook cache,
+//! run history). Payloads are gzipped, then sealed with XChaCha20-Poly1305.
+//! The key comes from `LAZYREQ_KEY` when set, otherwise from an
+//! auto-generated `~/.lazyreq/key` (created 0600 on first use).
+
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+const NONCE_LEN: usize = 24;
+
+pub fn lazyreq_dir() -> Result<PathBuf, String> {
+    let dir = home::home_dir()
+        .ok_or("cannot determine home directory".to_string())?
+        .join(".lazyreq");
+
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("cannot create directory `{}`: {}", dir.display(), e))?;
+
+    Ok(dir)
+}
+
+/// Stable identifier for a `.lreq` file: hash of its absolute path, so two
+/// projects with the same filename never share cache or history entries.
+pub fn file_id(filename: &str, extra: &str) -> String {
+    let absolute = fs::canonicalize(filename)
+        .unwrap_or_else(|_| {
+            std::env::current_dir()
+                .unwrap_or_default()
+                .join(filename)
+        });
+
+    let mut hasher = Sha256::new();
+    hasher.update(absolute.to_string_lossy().as_bytes());
+    hasher.update([0]);
+    hasher.update(extra.as_bytes());
+    hex::encode(&hasher.finalize()[..16])
+}
+
+/// Any key material becomes a cipher key through SHA-256, so env values,
+/// generated hex files and hand-edited key files all work.
+fn derive_key(material: &[u8]) -> Key {
+    *Key::from_slice(&Sha256::digest(material))
+}
+
+/// The raw key material is either `LAZYREQ_KEY` or the contents of
+/// `~/.lazyreq/key`.
+fn key() -> Result<Key, String> {
+    let material = match std::env::var("LAZYREQ_KEY") {
+        Ok(v) if !v.trim().is_empty() => v.into_bytes(),
+        _ => {
+            let path = lazyreq_dir()?.join("key");
+            match fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(_) => {
+                    let mut fresh = [0u8; 32];
+                    rand::rngs::OsRng.fill_bytes(&mut fresh);
+                    let encoded = hex::encode(fresh);
+                    fs::write(&path, &encoded)
+                        .map_err(|e| format!("cannot write key file `{}`: {}", path.display(), e))?;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+                    }
+                    encoded.into_bytes()
+                }
+            }
+        }
+    };
+
+    Ok(derive_key(&material))
+}
+
+/// gzip + encrypt; the output is `nonce || ciphertext`.
+pub fn seal(plain: &[u8]) -> Result<Vec<u8>, String> {
+    seal_with(&key()?, plain)
+}
+
+fn seal_with(key: &Key, plain: &[u8]) -> Result<Vec<u8>, String> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let compressed = encoder
+        .write_all(plain)
+        .and_then(|_| encoder.finish())
+        .map_err(|e| format!("cannot compress data: {}", e))?;
+
+    let cipher = XChaCha20Poly1305::new(key);
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+
+    let mut out = nonce.to_vec();
+    let sealed = cipher
+        .encrypt(XNonce::from_slice(&nonce), compressed.as_ref())
+        .map_err(|_| "cannot encrypt data".to_string())?;
+    out.extend(sealed);
+    Ok(out)
+}
+
+/// decrypt + gunzip. Any failure (wrong key, plaintext leftovers from older
+/// versions, corruption) yields `None`: treat as "no data", never an error.
+pub fn open(data: &[u8]) -> Option<Vec<u8>> {
+    open_with(&key().ok()?, data)
+}
+
+fn open_with(key: &Key, data: &[u8]) -> Option<Vec<u8>> {
+    if data.len() <= NONCE_LEN {
+        return None;
+    }
+
+    let cipher = XChaCha20Poly1305::new(key);
+    let compressed = cipher
+        .decrypt(XNonce::from_slice(&data[..NONCE_LEN]), &data[NONCE_LEN..])
+        .ok()?;
+
+    let mut plain = Vec::new();
+    GzDecoder::new(compressed.as_slice())
+        .read_to_end(&mut plain)
+        .ok()?;
+    Some(plain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let key = derive_key(b"test-key");
+        let plain = br#"{"token": "secret", "sizes": [1, 2, 3]}"#;
+
+        let sealed = seal_with(&key, plain).unwrap();
+        assert_ne!(&sealed[NONCE_LEN..], plain.as_slice());
+        assert_eq!(open_with(&key, &sealed).unwrap(), plain);
+    }
+
+    #[test]
+    fn open_rejects_wrong_key() {
+        let sealed = seal_with(&derive_key(b"key-a"), b"data").unwrap();
+        assert!(open_with(&derive_key(b"key-b"), &sealed).is_none());
+    }
+
+    #[test]
+    fn open_treats_garbage_as_empty() {
+        let key = derive_key(b"key");
+        assert!(open_with(&key, b"").is_none());
+        assert!(open_with(&key, b"short").is_none());
+        // plaintext leftovers from pre-encryption versions
+        assert!(open_with(&key, b"1783987601\n{\"cached\": \"response\"}\n").is_none());
+    }
+
+    #[test]
+    fn sealing_twice_differs_but_opens_the_same() {
+        let key = derive_key(b"key");
+        let a = seal_with(&key, b"same input").unwrap();
+        let b = seal_with(&key, b"same input").unwrap();
+
+        assert_ne!(a, b); // fresh nonce every write
+        assert_eq!(open_with(&key, &a), open_with(&key, &b));
+    }
+
+    #[test]
+    fn compression_shrinks_repetitive_payloads() {
+        let key = derive_key(b"key");
+        let plain = "{\"id\": 1, \"name\": \"aaaa\"},".repeat(500);
+        let sealed = seal_with(&key, plain.as_bytes()).unwrap();
+        assert!(sealed.len() < plain.len() / 10);
+    }
+
+    #[test]
+    fn file_id_distinguishes_paths_and_extras() {
+        let a = file_id("/tmp/project-a/api.lreq", "");
+        let b = file_id("/tmp/project-b/api.lreq", "");
+        let c = file_id("/tmp/project-a/api.lreq", "login");
+
+        assert_ne!(a, b); // same filename, different project
+        assert_ne!(a, c);
+        assert_eq!(a, file_id("/tmp/project-a/api.lreq", ""));
+        assert_eq!(a.len(), 32);
+    }
+}


### PR DESCRIPTION
## What's in here

- **Fix `=` in values**: headers/vars/hooks split on the first `=` only; surrounding quotes stripped
- **Friendly errors**: all panics replaced with `Result`-based messages (file/line + hint for parse errors, root-cause network errors, exit 1)
- **Built-in functions**: `$uuid()`, `$fuzz_str(len)`, `$fuzz_int(min,max)`, `$hmac(data,key,algo?,enc?)` (sha1/256/512 × hex/base64); bodies interpolated (lenient), `$body` available for signing
- **`--list`** and **`lazyreq import '<curl>'`** commands
- **`DESCRIPTION:`** lines on requests
- **CI**: rustls instead of vendored OpenSSL, rustup targets installed, `v*` tags release / PRs smoke-build
- README + MIT license

HMAC verified against Python's hmac; hooks/cache/multipart tested against a live local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)