### PR TITLE
fix(release): gitignore .zig-cache; prerelease: auto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Generated files
 /target/
 /dist/
+/.zig-cache/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,3 +40,6 @@ universal_binaries:
 
 source:
   enabled: true
+
+release:
+  prerelease: auto


### PR DESCRIPTION
Fixes the failed v0.2.0 release run: GoReleaser aborts tagged releases when the workspace is dirty, and the workflow's `ZIG_*_CACHE_DIR` create an untracked `.zig-cache/`. Snapshot (PR) builds skip that check, which is why CI was always green until the real tag.

Also sets `release.prerelease: auto` so semver pre-release tags (`v0.3.0-rc.1`) get GitHub's Pre-release label automatically.

After merging, the `v0.2.0` tag needs to be moved to the new main head and re-pushed to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)