### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyreq"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-recursion",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyreq"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A lazy, file-based HTTP client for your terminal"


### PR DESCRIPTION
Version bump for the next release: interactive TUI + themes, run ids + --retry, encrypted history/cache, install.sh, lazyreq update + TUI update notice.

After merging: `git tag v0.3.0 && git push origin v0.3.0` publishes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)